### PR TITLE
feat: add GitHub Pages showcase with repo stats and deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,43 @@
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+
+# Garante que apenas um deploy rode por vez; cancela runs anteriores pendentes
+concurrency:
+  group: github-pages-deploy
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    name: Build & Deploy Showcase
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate showcase directory
+        run: |
+          if [ ! -f "docs/showcase/index.html" ]; then
+            echo "::error::docs/showcase/index.html not found. Aborting deploy."
+            exit 1
+          fi
+          echo "Showcase directory validated."
+
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/showcase
+          publish_branch: gh-pages
+          keep_files: false
+          commit_message: "deploy: update showcase from ${{ github.sha }}"

--- a/.kiro/specs/github-pages-project-showcase/.config.kiro
+++ b/.kiro/specs/github-pages-project-showcase/.config.kiro
@@ -1,0 +1,1 @@
+{"specId": "a3cacbb7-9369-4cfd-aff3-1272836d6bf4", "workflowType": "requirements-first", "specType": "feature"}

--- a/.kiro/specs/github-pages-project-showcase/design.md
+++ b/.kiro/specs/github-pages-project-showcase/design.md
@@ -1,0 +1,538 @@
+# Design Document — GitHub Pages Project Showcase
+
+## Overview
+
+A Showcase_Page do Tokemize é um site estático (HTML + CSS + JavaScript puro) hospedado no GitHub Pages. Seu objetivo é apresentar o projeto de forma visual e profissional, exibindo estatísticas em tempo real do repositório, progresso de desenvolvimento por módulo, proposta de valor e membros da equipe.
+
+A página não possui backend próprio. Todos os dados dinâmicos são obtidos diretamente da GitHub REST API pública no lado do cliente (browser). O conteúdo configurável é lido de um arquivo `config.json` estático. O deploy é totalmente automatizado via GitHub Actions a cada push na branch `main`.
+
+### Objetivos de Design
+
+- **Zero dependência de backend**: toda a lógica roda no browser.
+- **Configuração declarativa**: conteúdo editável via `config.json` sem tocar no HTML.
+- **Resiliência a falhas de API**: cache local (localStorage) garante exibição mesmo offline.
+- **Performance**: carregamento completo em ≤ 3 segundos em 10 Mbps.
+- **Acessibilidade**: WCAG 2.1 AA (contraste ≥ 4.5:1, texto alternativo em gráficos).
+
+---
+
+## Architecture
+
+### Visão Geral
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                        GitHub Pages                         │
+│                                                             │
+│  ┌──────────┐   ┌──────────┐   ┌──────────┐   ┌─────────┐  │
+│  │ index.html│   │ style.css│   │  app.js  │   │config.  │  │
+│  │  (shell) │   │ (design) │   │ (lógica) │   │  json   │  │
+│  └──────────┘   └──────────┘   └──────────┘   └─────────┘  │
+│                        │                                    │
+│              ┌──────────▼──────────┐                        │
+│              │   Module Loader     │                        │
+│              │  (ES Modules / IIFE)│                        │
+│              └──────────┬──────────┘                        │
+│         ┌───────────────┼───────────────┐                   │
+│         ▼               ▼               ▼                   │
+│  ┌─────────────┐ ┌─────────────┐ ┌─────────────┐           │
+│  │ ConfigLoader│ │  ApiClient  │ │  CacheStore │           │
+│  └─────────────┘ └──────┬──────┘ └─────────────┘           │
+│                         │                                   │
+└─────────────────────────┼───────────────────────────────────┘
+                          │ fetch()
+                          ▼
+                 ┌─────────────────┐
+                 │  GitHub REST API│
+                 │  (api.github.com│
+                 │   /repos/...)   │
+                 └─────────────────┘
+```
+
+### Fluxo de Dados
+
+1. Browser carrega `index.html` → referencia `style.css` e `app.js`.
+2. `app.js` faz `fetch('config.json')` → popula conteúdo estático (nome, tagline, módulos, membros).
+3. `ApiClient` faz chamadas paralelas à GitHub API para buscar commits, PRs, contribuidores, branches e avatares.
+4. `CacheStore` (localStorage) é consultado antes de cada chamada à API; se o cache for válido (< 1 hora), os dados em cache são usados diretamente.
+5. Cada componente de UI recebe os dados e renderiza seu fragmento HTML/SVG.
+6. Em caso de falha na API, o componente exibe os dados em cache com indicador visual de desatualização.
+
+### Deploy Pipeline
+
+```
+push → main
+    └─► GitHub Actions (deploy.yml)
+            ├── checkout
+            ├── build (copy/minify assets)
+            └── deploy → gh-pages branch
+                    └─► GitHub Pages serve
+```
+
+---
+
+## Components and Interfaces
+
+### 1. `ConfigLoader`
+
+Responsável por carregar e validar o `config.json`.
+
+```javascript
+/**
+ * @typedef {Object} ModuleConfig
+ * @property {string} id        - Identificador do módulo (ex: "parser")
+ * @property {string} label     - Nome de exibição
+ * @property {"done"|"in_progress"|"planned"} status - Status manual
+ */
+
+/**
+ * @typedef {Object} TeamMember
+ * @property {string} name       - Nome completo
+ * @property {string} github     - Username do GitHub
+ * @property {string} [avatar]   - URL de avatar (opcional; fallback para API)
+ */
+
+/**
+ * @typedef {Object} AppConfig
+ * @property {string}         projectName
+ * @property {string}         tagline
+ * @property {ModuleConfig[]} modules
+ * @property {TeamMember[]}   team
+ * @property {Object}         links       - Links externos (docs, repo, etc.)
+ */
+
+async function loadConfig(): Promise<AppConfig>
+```
+
+- Se `config.json` estiver ausente ou malformado, retorna `DEFAULT_CONFIG` e emite `console.warn`.
+
+---
+
+### 2. `ApiClient`
+
+Abstração sobre a GitHub REST API. Todas as chamadas são feitas com `fetch` nativo.
+
+```javascript
+/**
+ * @typedef {Object} RepoStats
+ * @property {number} totalCommits
+ * @property {number} openPRs
+ * @property {number} closedPRs
+ * @property {number} contributors
+ * @property {number} activeBranches
+ * @property {string} lastCommitAt   - ISO 8601
+ */
+
+async function fetchRepoStats(owner: string, repo: string): Promise<RepoStats>
+async function fetchCommitActivity(owner: string, repo: string): Promise<WeeklyActivity[]>
+async function fetchAvatarUrl(username: string): Promise<string>
+```
+
+- Todas as funções lançam `ApiError` em caso de falha HTTP (status ≥ 400 ou timeout).
+- Timeout configurável via `config.json` (padrão: 8 segundos).
+
+---
+
+### 3. `CacheStore`
+
+Camada de cache sobre `localStorage`.
+
+```javascript
+/**
+ * @typedef {Object} CacheEntry<T>
+ * @property {T}      data
+ * @property {number} timestamp  - Unix ms
+ */
+
+function get<T>(key: string): T | null
+function set<T>(key: string, data: T): void
+function isStale(key: string, maxAgeMs: number): boolean
+```
+
+- TTL padrão: 3600000 ms (1 hora), alinhado ao requisito 2.7.
+- Chaves prefixadas com `tokemize_cache_` para evitar colisões.
+
+---
+
+### 4. Componentes de UI
+
+Cada componente é uma função pura que recebe dados e retorna/atualiza um fragmento do DOM.
+
+| Componente | Elemento alvo | Dados de entrada |
+|---|---|---|
+| `renderHero(config)` | `#hero` | `AppConfig` |
+| `renderStats(stats, stale)` | `#stats` | `RepoStats`, `boolean` |
+| `renderContributionGraph(activity)` | `#contribution-graph` | `WeeklyActivity[]` |
+| `renderProgressTracker(modules)` | `#progress` | `ModuleConfig[]` |
+| `renderTeam(members, avatars)` | `#team` | `TeamMember[]`, `Map<string,string>` |
+| `renderPipeline(config)` | `#pipeline` | `AppConfig` |
+| `renderTechStack(config)` | `#tech-stack` | `AppConfig` |
+
+---
+
+### 5. `ContributionGraph`
+
+Renderiza um gráfico de barras SVG com atividade semanal de commits.
+
+- Dados: array de `{ week: string, commits: number, byAuthor: Record<string, number> }` (últimas 13 semanas ≈ 90 dias).
+- Tooltip: elemento `<div role="tooltip">` posicionado via `mousemove`.
+- Acessibilidade: `<svg aria-label="Gráfico de contribuições: X commits nas últimas 13 semanas">` + `<title>` interno.
+
+---
+
+### 6. `ProgressTracker`
+
+Calcula e exibe o progresso por módulo.
+
+```
+percentual = (módulos com status "done" / total de módulos) × 100
+```
+
+- Status manual em `config.json` tem prioridade absoluta (requisito 4.4).
+- Exibe barra de progresso geral + badge de status por módulo.
+
+---
+
+### 7. Deploy Workflow (`deploy.yml`)
+
+```yaml
+name: Deploy GitHub Pages
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    permissions:
+      contents: write
+    steps:
+      - uses: actions/checkout@v4
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./docs/showcase
+          keep_files: false
+```
+
+- Em caso de falha no build, o workflow termina com `exit 1` sem sobrescrever o branch `gh-pages`.
+- Timeout de 5 minutos alinhado ao requisito 1.2.
+
+---
+
+## Data Models
+
+### `config.json` — Estrutura Completa
+
+```json
+{
+  "projectName": "Tokemize",
+  "tagline": "Uma camada intermediária que melhora como usamos IA",
+  "repo": {
+    "owner": "tokemize-org",
+    "name": "tokemize",
+    "apiTimeout": 8000
+  },
+  "problems": [
+    "Alto custo de tokens",
+    "Respostas imprecisas e alucinações",
+    "Processamento ineficiente"
+  ],
+  "pipeline": ["Entrada Bruta", "Tokemize", "Entrada Otimizada"],
+  "techStack": [
+    { "name": "Python", "url": "https://docs.python.org/3/" },
+    { "name": "Tree-sitter", "url": "https://tree-sitter.github.io/tree-sitter/" },
+    { "name": "FAISS", "url": "https://faiss.ai/index.html" },
+    { "name": "OpenAI API", "url": "https://platform.openai.com/docs" },
+    { "name": "Anthropic API", "url": "https://docs.anthropic.com" }
+  ],
+  "modules": [
+    { "id": "parser",                "label": "Parser",              "status": "in_progress" },
+    { "id": "indexer",               "label": "Indexer",             "status": "in_progress" },
+    { "id": "selector",              "label": "Selector",            "status": "planned"     },
+    { "id": "optimizer",             "label": "Optimizer",           "status": "planned"     },
+    { "id": "integrations/llm",      "label": "LLM Integration",     "status": "in_progress" },
+    { "id": "integrations/embeddings","label": "Embeddings",         "status": "planned"     }
+  ],
+  "team": [
+    { "name": "Eneri da Costa Junior",       "github": "jrcosta"          },
+    { "name": "Guilherme Valerio Mertens",   "github": "gvmertens"        },
+    { "name": "Paulo Sergio",                "github": "PauloSergioLR"    },
+    { "name": "Samuel Magalhães Marques",    "github": "samuelmarquesgit" },
+    { "name": "Eduardo Notari",              "github": "edunotari"        }
+  ],
+  "links": {
+    "repo": "https://github.com/tokemize-org/tokemize",
+    "readme": "https://github.com/tokemize-org/tokemize#readme"
+  }
+}
+```
+
+### `WeeklyActivity`
+
+```typescript
+interface WeeklyActivity {
+  week: string;           // ISO date do início da semana (ex: "2025-01-06")
+  totalCommits: number;
+  byAuthor: Record<string, number>; // { "username": commitCount }
+}
+```
+
+### `CacheEntry<T>`
+
+```typescript
+interface CacheEntry<T> {
+  data: T;
+  timestamp: number;  // Date.now()
+}
+```
+
+### `ApiError`
+
+```typescript
+class ApiError extends Error {
+  constructor(
+    public readonly status: number,
+    public readonly endpoint: string,
+    message: string
+  ) { super(message); }
+}
+```
+
+---
+
+## Correctness Properties
+
+
+*A property is a characteristic or behavior that should hold true across all valid executions of a system — essentially, a formal statement about what the system should do. Properties serve as the bridge between human-readable specifications and machine-verifiable correctness guarantees.*
+
+### Property 1: Stats_Widget renderiza todos os campos de RepoStats
+
+*For any* `RepoStats` object, `renderStats(stats, stale)` SHALL produce HTML containing the values of `totalCommits`, `openPRs`, `closedPRs`, `contributors`, `activeBranches`, and a formatted representation of `lastCommitAt`.
+
+**Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5**
+
+---
+
+### Property 2: Indicador de dados desatualizados é exibido quando cache é stale
+
+*For any* `RepoStats` object, when `renderStats(stats, stale=true)` is called, the rendered HTML SHALL contain a stale-indicator element (e.g., an element with `data-stale="true"` or a specific CSS class).
+
+**Validates: Requirements 2.6**
+
+---
+
+### Property 3: CacheStore.isStale respeita o TTL de 1 hora
+
+*For any* cache entry timestamp `t` and `maxAge = 3600000` ms, `isStale(key, maxAge)` SHALL return `true` if and only if `(Date.now() - t) > maxAge`.
+
+**Validates: Requirements 2.7**
+
+---
+
+### Property 4: Contribution_Graph cobre exatamente as últimas 13 semanas
+
+*For any* commit activity array, the data passed to the graph renderer SHALL contain only weeks whose start date falls within the last 90 days (≈ 13 weeks) relative to the current date.
+
+**Validates: Requirements 3.1**
+
+---
+
+### Property 5: Contribution_Graph atribui cores distintas por autor
+
+*For any* `WeeklyActivity` array with N distinct author usernames, the color mapping function SHALL assign N distinct color values — one per author.
+
+**Validates: Requirements 3.2**
+
+---
+
+### Property 6: Contribution_Graph SVG possui atributo de acessibilidade não vazio
+
+*For any* `WeeklyActivity` array, the SVG element rendered by `renderContributionGraph` SHALL have a non-empty `aria-label` attribute describing the graph content.
+
+**Validates: Requirements 3.4**
+
+---
+
+### Property 7: Progress_Tracker renderiza label e status de cada módulo
+
+*For any* non-empty array of `ModuleConfig` objects, `renderProgressTracker(modules)` SHALL produce HTML containing each module's `label` and a visual representation of its `status`.
+
+**Validates: Requirements 4.1, 4.2**
+
+---
+
+### Property 8: calculateProgress retorna a porcentagem correta de módulos concluídos
+
+*For any* non-empty array of `ModuleConfig` objects, `calculateProgress(modules)` SHALL return `(count of modules with status "done" / modules.length) * 100`.
+
+**Validates: Requirements 4.3**
+
+---
+
+### Property 9: Status manual tem prioridade absoluta no Progress_Tracker
+
+*For any* `ModuleConfig` with an explicit `status` field, the status displayed by `renderProgressTracker` SHALL always equal the configured value, regardless of any other input or inferred state.
+
+**Validates: Requirements 4.4**
+
+---
+
+### Property 10: renderHero exibe todos os campos de conteúdo da hero section
+
+*For any* `AppConfig`, `renderHero(config)` SHALL produce HTML containing `config.projectName`, `config.tagline`, each string in `config.problems`, and each step in `config.pipeline`.
+
+**Validates: Requirements 5.1, 5.2, 5.3**
+
+---
+
+### Property 11: renderTechStack exibe nome e link de cada tecnologia
+
+*For any* `AppConfig` with a non-empty `techStack` array, `renderTechStack(config)` SHALL produce HTML containing each technology's `name` as visible text and its `url` as an anchor `href`.
+
+**Validates: Requirements 5.4**
+
+---
+
+### Property 12: renderTeam exibe nome e link GitHub de cada membro
+
+*For any* array of `TeamMember` objects, `renderTeam(members, avatars)` SHALL produce HTML containing each member's `name` and an anchor with `href` equal to `https://github.com/{member.github}`.
+
+**Validates: Requirements 6.1**
+
+---
+
+### Property 13: Avatar do membro é exibido quando disponível
+
+*For any* `TeamMember` and a non-null avatar URL in the avatars map, `renderTeam` SHALL produce an `<img>` element with `src` equal to the provided avatar URL for that member.
+
+**Validates: Requirements 6.2**
+
+---
+
+### Property 14: Avatar padrão é exibido quando API não está disponível
+
+*For any* `TeamMember` whose username is absent from the avatars map (or the map is empty), `renderTeam` SHALL produce an `<img>` element with `src` equal to the default avatar path.
+
+**Validates: Requirements 6.3**
+
+---
+
+### Property 15: loadConfig faz round-trip completo de AppConfig
+
+*For any* valid `AppConfig` object containing all required fields (`projectName`, `tagline`, `modules`, `team`, `links`), serializing it to JSON and loading it via `loadConfig()` SHALL return an object deeply equal to the original.
+
+**Validates: Requirements 8.1, 8.3**
+
+---
+
+### Property 16: loadConfig retorna DEFAULT_CONFIG para entradas inválidas
+
+*For any* input that is `null`, `undefined`, an empty string, syntactically invalid JSON, or a JSON object missing required fields, `loadConfig()` SHALL return `DEFAULT_CONFIG` without throwing an exception.
+
+**Validates: Requirements 8.4**
+
+---
+
+## Error Handling
+
+### Falhas na GitHub API
+
+| Cenário | Comportamento |
+|---|---|
+| HTTP 4xx / 5xx | `ApiClient` lança `ApiError`; componente usa dados do cache |
+| Timeout (> 8s) | `fetch` é abortado via `AbortController`; `ApiError` é lançado |
+| Cache vazio + API falhou | Componente exibe estado de erro com mensagem amigável |
+| Cache stale + API falhou | Dados em cache são exibidos com indicador visual de desatualização |
+
+### Falhas no config.json
+
+| Cenário | Comportamento |
+|---|---|
+| Arquivo ausente (404) | `loadConfig()` retorna `DEFAULT_CONFIG`; `console.warn` emitido |
+| JSON malformado | `JSON.parse` lança `SyntaxError`; capturado, retorna `DEFAULT_CONFIG` |
+| Campos obrigatórios ausentes | Validação de schema retorna `DEFAULT_CONFIG` para campos faltantes |
+
+### Falhas no Deploy
+
+- O workflow usa `peaceiris/actions-gh-pages` com `keep_files: false` apenas após build bem-sucedido.
+- Se qualquer step falhar, o job termina com código de saída não-zero e o branch `gh-pages` não é modificado.
+- Erros são visíveis nos logs do GitHub Actions (requisito 1.3).
+
+---
+
+## Testing Strategy
+
+### Abordagem Dual
+
+A estratégia combina testes de exemplo (unit tests) para comportamentos específicos e testes baseados em propriedades (property-based tests) para verificar invariantes universais.
+
+### Property-Based Testing
+
+**Biblioteca**: [fast-check](https://fast-check.dev/) (JavaScript) — escolhida por ser a biblioteca PBT mais madura para o ecossistema JS/TS, com suporte a geradores arbitrários complexos e shrinking automático.
+
+**Configuração**: mínimo de 100 iterações por propriedade (`numRuns: 100`).
+
+**Tag de referência**: cada teste deve incluir um comentário no formato:
+```
+// Feature: github-pages-project-showcase, Property N: <texto da propriedade>
+```
+
+**Propriedades implementadas como testes PBT** (uma por propriedade):
+
+| Propriedade | Função testada | Arbitrários |
+|---|---|---|
+| P1 | `renderStats` | `fc.record({ totalCommits: fc.nat(), openPRs: fc.nat(), ... })` |
+| P2 | `renderStats` (stale) | mesmo record + `stale=true` |
+| P3 | `CacheStore.isStale` | `fc.integer()` para timestamp |
+| P4 | filtro de semanas | `fc.array(weeklyActivityArb)` |
+| P5 | mapeamento de cores | `fc.array(fc.string(), { minLength: 1 })` para autores |
+| P6 | `renderContributionGraph` | `fc.array(weeklyActivityArb)` |
+| P7 | `renderProgressTracker` | `fc.array(moduleConfigArb, { minLength: 1 })` |
+| P8 | `calculateProgress` | `fc.array(moduleConfigArb, { minLength: 1 })` |
+| P9 | `renderProgressTracker` (prioridade) | `moduleConfigArb` com status explícito |
+| P10 | `renderHero` | `appConfigArb` |
+| P11 | `renderTechStack` | `appConfigArb` com techStack não vazio |
+| P12 | `renderTeam` | `fc.array(teamMemberArb, { minLength: 1 })` |
+| P13 | `renderTeam` (avatar presente) | `teamMemberArb` + `fc.webUrl()` |
+| P14 | `renderTeam` (avatar ausente) | `teamMemberArb` + mapa vazio |
+| P15 | `loadConfig` round-trip | `appConfigArb` |
+| P16 | `loadConfig` fallback | `fc.oneof(fc.constant(null), fc.string(), invalidJsonArb)` |
+
+### Unit Tests (Testes de Exemplo)
+
+Focados em cenários específicos não cobertos pelas propriedades:
+
+- Tooltip do `ContributionGraph` ao passar o cursor (requisito 3.3) — simula evento `mousemove`.
+- Contraste de cores WCAG 2.1 AA (requisito 7.3) — verifica cada par texto/fundo definido no CSS.
+- Renderização com dados reais do repositório Tokemize (smoke test de integração).
+
+### Testes de Integração / Smoke
+
+- Verificar que o workflow de deploy é acionado por push na `main`.
+- Verificar que a URL do GitHub Pages retorna HTTP 200 após deploy.
+- Verificar que falha no build não sobrescreve o branch `gh-pages`.
+- Verificar tempo de carregamento com Lighthouse (≤ 3s em 10 Mbps).
+
+### Estrutura de Arquivos de Teste
+
+```
+docs/showcase/
+├── index.html
+├── style.css
+├── config.json
+├── app.js
+└── __tests__/
+    ├── configLoader.test.js      # P15, P16 + unit tests
+    ├── apiClient.test.js         # mocks de fetch
+    ├── cacheStore.test.js        # P3
+    ├── renderStats.test.js       # P1, P2
+    ├── renderContributionGraph.test.js  # P4, P5, P6 + tooltip example
+    ├── renderProgressTracker.test.js    # P7, P8, P9
+    ├── renderHero.test.js        # P10
+    ├── renderTechStack.test.js   # P11
+    └── renderTeam.test.js        # P12, P13, P14
+```

--- a/.kiro/specs/github-pages-project-showcase/requirements.md
+++ b/.kiro/specs/github-pages-project-showcase/requirements.md
@@ -1,0 +1,125 @@
+# Requirements Document
+
+## Introduction
+
+A página GitHub Pages do Tokemize é um site estático de showcase do projeto, hospedado via GitHub Pages e atualizado automaticamente por GitHub Actions. O objetivo é apresentar o projeto de forma visual e profissional em apresentações, exibindo estatísticas de contribuições, progresso do desenvolvimento, a proposta de valor do produto e os membros da equipe. A página deve ser autoexplicativa para qualquer pessoa que acesse o repositório ou assista a uma apresentação.
+
+## Glossary
+
+- **Showcase_Page**: A página GitHub Pages estática do projeto Tokemize.
+- **GitHub_Actions**: Serviço de CI/CD do GitHub responsável por construir e publicar a página automaticamente.
+- **Stats_Widget**: Componente visual que exibe uma métrica específica do projeto (ex: número de commits, PRs, contribuidores).
+- **Contribution_Graph**: Visualização gráfica da atividade de commits ao longo do tempo.
+- **Progress_Tracker**: Componente que exibe o progresso de desenvolvimento por módulo ou milestone.
+- **GitHub_API**: API REST pública do GitHub usada para buscar dados do repositório em tempo real.
+- **Static_Site**: Site composto apenas por HTML, CSS e JavaScript, sem backend próprio.
+- **Deploy_Workflow**: Workflow do GitHub Actions responsável por publicar a Showcase_Page no branch `gh-pages`.
+
+---
+
+## Requirements
+
+### Requirement 1: Publicação Automática via GitHub Actions
+
+**User Story:** Como membro da equipe, quero que a página seja publicada automaticamente a cada push na branch principal, para que o showcase esteja sempre atualizado sem intervenção manual.
+
+#### Acceptance Criteria
+
+1. WHEN um push é feito na branch `main`, THE Deploy_Workflow SHALL construir e publicar a Showcase_Page no branch `gh-pages`.
+2. THE Deploy_Workflow SHALL concluir a publicação em no máximo 5 minutos após o push.
+3. IF o build da Showcase_Page falhar, THEN THE Deploy_Workflow SHALL registrar o erro no log do GitHub Actions e interromper o deploy sem sobrescrever a versão anterior publicada.
+4. THE Showcase_Page SHALL estar acessível via URL pública do GitHub Pages após cada deploy bem-sucedido.
+
+---
+
+### Requirement 2: Exibição de Estatísticas do Repositório
+
+**User Story:** Como apresentador do projeto, quero ver estatísticas atualizadas do repositório na página, para demonstrar o progresso e a atividade do projeto durante apresentações.
+
+#### Acceptance Criteria
+
+1. WHEN a Showcase_Page é carregada, THE Stats_Widget SHALL exibir o número total de commits do repositório.
+2. WHEN a Showcase_Page é carregada, THE Stats_Widget SHALL exibir o número de pull requests abertos e fechados.
+3. WHEN a Showcase_Page é carregada, THE Stats_Widget SHALL exibir o número de contribuidores únicos do repositório.
+4. WHEN a Showcase_Page é carregada, THE Stats_Widget SHALL exibir o número de branches ativas.
+5. WHEN a Showcase_Page é carregada, THE Stats_Widget SHALL exibir a data e hora do último commit na branch `main`.
+6. IF a GitHub_API retornar erro ou timeout, THEN THE Stats_Widget SHALL exibir o último valor em cache e indicar visualmente que os dados podem estar desatualizados.
+7. THE Stats_Widget SHALL atualizar os dados via GitHub_API com no máximo 1 hora de defasagem em relação ao estado real do repositório.
+
+---
+
+### Requirement 3: Visualização do Gráfico de Contribuições
+
+**User Story:** Como apresentador do projeto, quero exibir um gráfico de atividade de commits ao longo do tempo, para mostrar visualmente o ritmo de desenvolvimento da equipe.
+
+#### Acceptance Criteria
+
+1. WHEN a Showcase_Page é carregada, THE Contribution_Graph SHALL exibir a frequência de commits agrupados por semana nos últimos 90 dias.
+2. THE Contribution_Graph SHALL diferenciar visualmente as contribuições por autor usando cores distintas.
+3. WHEN o usuário passa o cursor sobre uma barra do Contribution_Graph, THE Contribution_Graph SHALL exibir um tooltip com o número de commits e o período correspondente.
+4. THE Contribution_Graph SHALL ser renderizado como um elemento SVG ou Canvas acessível, com texto alternativo descrevendo o conteúdo.
+
+---
+
+### Requirement 4: Rastreamento de Progresso por Módulo
+
+**User Story:** Como apresentador do projeto, quero exibir o progresso de implementação de cada módulo do Tokemize, para mostrar o que já foi construído e o que está em desenvolvimento.
+
+#### Acceptance Criteria
+
+1. THE Progress_Tracker SHALL exibir o status de cada módulo principal do Tokemize: `parser`, `indexer`, `selector`, `optimizer`, `integrations/llm` e `integrations/embeddings`.
+2. WHEN um módulo possui arquivos de código-fonte no repositório, THE Progress_Tracker SHALL exibir o status desse módulo como "Em desenvolvimento" ou "Concluído" com base em critério configurável no arquivo de configuração da página.
+3. THE Progress_Tracker SHALL representar o progresso geral do projeto como uma porcentagem calculada a partir do número de módulos com status "Concluído" em relação ao total de módulos.
+4. WHERE o status de um módulo for configurado manualmente, THE Progress_Tracker SHALL priorizar o valor configurado sobre qualquer inferência automática.
+
+---
+
+### Requirement 5: Apresentação da Proposta de Valor
+
+**User Story:** Como visitante da página, quero entender rapidamente o que é o Tokemize e qual problema ele resolve, para que eu possa compreender o projeto sem precisar ler o README.
+
+#### Acceptance Criteria
+
+1. THE Showcase_Page SHALL exibir o nome do projeto "Tokemize" e o tagline *"Uma camada intermediária que melhora como usamos IA"* na seção principal (hero).
+2. THE Showcase_Page SHALL exibir os três problemas principais que o Tokemize resolve: alto custo de tokens, respostas imprecisas e processamento ineficiente.
+3. THE Showcase_Page SHALL exibir o fluxo do pipeline de forma visual: `Entrada Bruta → Tokemize → Entrada Otimizada`.
+4. THE Showcase_Page SHALL exibir as tecnologias utilizadas (Python, Tree-sitter, FAISS, OpenAI API, Anthropic API) com links para suas respectivas documentações oficiais.
+
+---
+
+### Requirement 6: Exibição dos Membros da Equipe
+
+**User Story:** Como visitante da página, quero ver quem são os membros da equipe do Tokemize, para reconhecer os contribuidores do projeto.
+
+#### Acceptance Criteria
+
+1. THE Showcase_Page SHALL exibir o nome e o link para o perfil GitHub de cada membro da equipe: Eneri da Costa Junior, Guilherme Valerio Mertens, Paulo Sergio, Samuel Magalhães Marques e Eduardo Notari.
+2. WHEN a GitHub_API estiver disponível, THE Showcase_Page SHALL exibir o avatar de cada membro carregado diretamente do perfil GitHub correspondente.
+3. IF a GitHub_API não estiver disponível, THEN THE Showcase_Page SHALL exibir um avatar padrão no lugar da foto do membro.
+
+---
+
+### Requirement 7: Design Responsivo e Adequado para Apresentações
+
+**User Story:** Como apresentador do projeto, quero que a página seja visualmente clara em telas grandes (projetores e monitores), para que o conteúdo seja legível durante apresentações.
+
+#### Acceptance Criteria
+
+1. THE Showcase_Page SHALL ser renderizada corretamente em resoluções de 1280×720, 1920×1080 e 2560×1440.
+2. THE Showcase_Page SHALL ser renderizada corretamente em dispositivos móveis com largura mínima de 375px.
+3. THE Showcase_Page SHALL utilizar contraste de cores com razão mínima de 4.5:1 entre texto e fundo, conforme WCAG 2.1 nível AA.
+4. THE Showcase_Page SHALL carregar completamente em no máximo 3 segundos em conexão de 10 Mbps.
+5. THE Showcase_Page SHALL ser implementada como um Static_Site sem dependência de backend próprio, utilizando apenas HTML, CSS e JavaScript.
+
+---
+
+### Requirement 8: Configuração Declarativa do Conteúdo
+
+**User Story:** Como membro da equipe, quero poder atualizar o conteúdo da página (status dos módulos, textos, links) editando um arquivo de configuração, para não precisar modificar o HTML diretamente.
+
+#### Acceptance Criteria
+
+1. THE Showcase_Page SHALL ler as configurações de conteúdo a partir de um arquivo `config.json` localizado na raiz do projeto da página.
+2. WHEN o arquivo `config.json` é atualizado e um push é feito na branch `main`, THE Deploy_Workflow SHALL publicar a Showcase_Page com o conteúdo atualizado automaticamente.
+3. THE `config.json` SHALL permitir configurar: nome do projeto, tagline, lista de módulos com seus status, lista de membros da equipe e links externos.
+4. IF o arquivo `config.json` estiver ausente ou malformado, THEN THE Showcase_Page SHALL exibir os valores padrão definidos em código e registrar um aviso no console do navegador.

--- a/.kiro/specs/github-pages-project-showcase/tasks.md
+++ b/.kiro/specs/github-pages-project-showcase/tasks.md
@@ -1,0 +1,253 @@
+# Implementation Plan: GitHub Pages Project Showcase
+
+## Overview
+
+Implementação da Showcase_Page do Tokemize como um site estático (HTML + CSS + JavaScript puro) hospedado no GitHub Pages. A implementação segue a arquitetura definida no design: `ConfigLoader`, `ApiClient`, `CacheStore` e componentes de UI independentes, com deploy automatizado via GitHub Actions e testes baseados em propriedades usando fast-check.
+
+## Tasks
+
+- [x] 1. Estrutura do projeto e configuração inicial
+  - Criar o diretório `docs/showcase/` com a estrutura de arquivos definida no design
+  - Criar `docs/showcase/index.html` com o shell HTML semântico (seções `#hero`, `#stats`, `#contribution-graph`, `#progress`, `#pipeline`, `#tech-stack`, `#team`)
+  - Criar `docs/showcase/style.css` com variáveis CSS, reset e layout base responsivo (grid/flexbox)
+  - Criar `docs/showcase/app.js` como entry point que importa e inicializa todos os módulos
+  - Criar `docs/showcase/config.json` com os dados completos do Tokemize conforme o modelo de dados do design (projectName, tagline, repo, problems, pipeline, techStack, modules, team, links)
+  - Configurar `package.json` em `docs/showcase/` com fast-check e Vitest como dependências de desenvolvimento
+  - Criar `docs/showcase/__tests__/` com arquivos de teste vazios para cada módulo
+  - _Requirements: 7.5, 8.1, 8.3_
+
+- [x] 2. Implementar `ConfigLoader`
+  - [x] 2.1 Implementar `loadConfig()` em `docs/showcase/configLoader.js`
+    - Fazer `fetch('config.json')` e parsear o JSON retornado
+    - Validar presença dos campos obrigatórios (`projectName`, `tagline`, `modules`, `team`, `links`)
+    - Retornar `DEFAULT_CONFIG` e emitir `console.warn` se o arquivo estiver ausente (404), malformado (SyntaxError) ou com campos obrigatórios faltando
+    - Exportar `DEFAULT_CONFIG` como constante com valores padrão do Tokemize
+    - _Requirements: 8.1, 8.4_
+
+  - [ ]* 2.2 Escrever property test para `loadConfig` — round-trip (P15)
+    - **Property 15: loadConfig faz round-trip completo de AppConfig**
+    - **Validates: Requirements 8.1, 8.3**
+    - Usar `fc.record` com todos os campos obrigatórios de `AppConfig`
+    - Serializar para JSON, mockar `fetch` para retornar esse JSON e verificar igualdade profunda com o objeto original
+
+  - [ ]* 2.3 Escrever property test para `loadConfig` — fallback para entradas inválidas (P16)
+    - **Property 16: loadConfig retorna DEFAULT_CONFIG para entradas inválidas**
+    - **Validates: Requirements 8.4**
+    - Usar `fc.oneof(fc.constant(null), fc.string(), fc.record({...}))` para gerar entradas inválidas
+    - Verificar que `loadConfig()` retorna `DEFAULT_CONFIG` sem lançar exceção
+
+- [x] 3. Implementar `CacheStore`
+  - [x] 3.1 Implementar `CacheStore` em `docs/showcase/cacheStore.js`
+    - Implementar `get(key)`, `set(key, data)` e `isStale(key, maxAgeMs)` sobre `localStorage`
+    - Prefixar todas as chaves com `tokemize_cache_`
+    - TTL padrão de 3600000 ms (1 hora)
+    - `isStale` retorna `true` se `(Date.now() - entry.timestamp) > maxAgeMs`
+    - Tratar `localStorage` indisponível (modo privado) com try/catch silencioso
+    - _Requirements: 2.7_
+
+  - [ ]* 3.2 Escrever property test para `CacheStore.isStale` (P3)
+    - **Property 3: CacheStore.isStale respeita o TTL de 1 hora**
+    - **Validates: Requirements 2.7**
+    - Usar `fc.integer({ min: 0, max: Date.now() })` para gerar timestamps
+    - Verificar que `isStale` retorna `true` se e somente se `(Date.now() - t) > 3600000`
+
+- [x] 4. Implementar `ApiClient`
+  - [x] 4.1 Implementar `ApiClient` em `docs/showcase/apiClient.js`
+    - Implementar `fetchRepoStats(owner, repo)` agregando chamadas paralelas à GitHub REST API: commits (`/commits?per_page=1`), PRs (`/pulls?state=all`), contributors (`/contributors`), branches (`/branches`) e último commit na main
+    - Implementar `fetchCommitActivity(owner, repo)` usando `/stats/commit_activity` e filtrando as últimas 13 semanas
+    - Implementar `fetchAvatarUrl(username)` via `/users/{username}`
+    - Usar `AbortController` com timeout configurável (padrão 8s via `config.json`)
+    - Lançar `ApiError` (classe definida no design) para status HTTP ≥ 400 ou timeout
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 3.1_
+
+  - [ ]* 4.2 Escrever unit tests para `ApiClient` com mocks de fetch
+    - Testar resposta bem-sucedida retorna `RepoStats` corretamente mapeado
+    - Testar HTTP 4xx lança `ApiError` com status e endpoint corretos
+    - Testar timeout (AbortController) lança `ApiError`
+    - _Requirements: 2.6_
+
+- [x] 5. Checkpoint — Verificar módulos base
+  - Garantir que `ConfigLoader`, `CacheStore` e `ApiClient` passam em todos os testes
+  - Verificar que `config.json` é carregado corretamente no browser (abrir `index.html` localmente)
+  - Perguntar ao usuário se há dúvidas antes de prosseguir para os componentes de UI
+
+- [x] 6. Implementar componente `renderHero`
+  - [x] 6.1 Implementar `renderHero(config)` em `docs/showcase/components/hero.js`
+    - Renderizar `config.projectName` e `config.tagline` na seção `#hero`
+    - Renderizar os três problemas de `config.problems` como lista visual
+    - Renderizar o fluxo do pipeline `config.pipeline` como sequência visual com setas
+    - _Requirements: 5.1, 5.2, 5.3_
+
+  - [ ]* 6.2 Escrever property test para `renderHero` (P10)
+    - **Property 10: renderHero exibe todos os campos de conteúdo da hero section**
+    - **Validates: Requirements 5.1, 5.2, 5.3**
+    - Usar `fc.record` para gerar `AppConfig` com `projectName`, `tagline`, `problems` e `pipeline` arbitrários
+    - Verificar que o HTML resultante contém cada valor gerado
+
+- [x] 7. Implementar componente `renderTechStack`
+  - [x] 7.1 Implementar `renderTechStack(config)` em `docs/showcase/components/techStack.js`
+    - Renderizar cada item de `config.techStack` com `name` como texto visível e `url` como `href` do anchor
+    - Adicionar `target="_blank" rel="noopener noreferrer"` em todos os links externos
+    - _Requirements: 5.4_
+
+  - [ ]* 7.2 Escrever property test para `renderTechStack` (P11)
+    - **Property 11: renderTechStack exibe nome e link de cada tecnologia**
+    - **Validates: Requirements 5.4**
+    - Usar `fc.array(fc.record({ name: fc.string({ minLength: 1 }), url: fc.webUrl() }), { minLength: 1 })`
+    - Verificar que cada `name` aparece como texto e cada `url` aparece como `href`
+
+- [x] 8. Implementar componente `renderStats`
+  - [x] 8.1 Implementar `renderStats(stats, stale)` em `docs/showcase/components/stats.js`
+    - Renderizar os seis campos de `RepoStats` na seção `#stats`: `totalCommits`, `openPRs`, `closedPRs`, `contributors`, `activeBranches` e `lastCommitAt` formatado
+    - Quando `stale=true`, adicionar elemento com `data-stale="true"` e mensagem visual de dados desatualizados
+    - Quando `stats` é `null` (cache vazio + API falhou), exibir estado de erro com mensagem amigável
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6_
+
+  - [ ]* 8.2 Escrever property test para `renderStats` — todos os campos (P1)
+    - **Property 1: Stats_Widget renderiza todos os campos de RepoStats**
+    - **Validates: Requirements 2.1, 2.2, 2.3, 2.4, 2.5**
+    - Usar `fc.record({ totalCommits: fc.nat(), openPRs: fc.nat(), closedPRs: fc.nat(), contributors: fc.nat(), activeBranches: fc.nat(), lastCommitAt: fc.date().map(d => d.toISOString()) })`
+    - Verificar que o HTML contém cada valor numérico e a data formatada
+
+  - [ ]* 8.3 Escrever property test para `renderStats` — indicador stale (P2)
+    - **Property 2: Indicador de dados desatualizados é exibido quando cache é stale**
+    - **Validates: Requirements 2.6**
+    - Usar o mesmo `fc.record` de P1 com `stale=true`
+    - Verificar que o HTML contém elemento com `data-stale="true"`
+
+- [x] 9. Implementar componente `renderContributionGraph`
+  - [x] 9.1 Implementar `renderContributionGraph(activity)` em `docs/showcase/components/contributionGraph.js`
+    - Renderizar gráfico de barras SVG com as semanas de `WeeklyActivity[]`
+    - Implementar função de mapeamento de cores por autor (uma cor distinta por username)
+    - Adicionar `aria-label` descritivo no elemento `<svg>` e `<title>` interno
+    - Implementar tooltip `<div role="tooltip">` posicionado via evento `mousemove` em cada barra
+    - _Requirements: 3.1, 3.2, 3.3, 3.4_
+
+  - [ ]* 9.2 Escrever property test — filtro das últimas 13 semanas (P4)
+    - **Property 4: Contribution_Graph cobre exatamente as últimas 13 semanas**
+    - **Validates: Requirements 3.1**
+    - Usar `fc.array(fc.record({ week: fc.date().map(d => d.toISOString().slice(0,10)), totalCommits: fc.nat(), byAuthor: fc.dictionary(fc.string(), fc.nat()) }))`
+    - Verificar que apenas semanas dentro dos últimos 90 dias são passadas ao renderer
+
+  - [ ]* 9.3 Escrever property test — cores distintas por autor (P5)
+    - **Property 5: Contribution_Graph atribui cores distintas por autor**
+    - **Validates: Requirements 3.2**
+    - Usar `fc.array(fc.string({ minLength: 1 }), { minLength: 1 })` para gerar N autores distintos
+    - Verificar que a função de mapeamento de cores retorna N valores distintos
+
+  - [ ]* 9.4 Escrever property test — aria-label não vazio no SVG (P6)
+    - **Property 6: Contribution_Graph SVG possui atributo de acessibilidade não vazio**
+    - **Validates: Requirements 3.4**
+    - Usar `fc.array(weeklyActivityArb)` para gerar dados arbitrários
+    - Verificar que o SVG renderizado possui `aria-label` com valor não vazio
+
+  - [ ]* 9.5 Escrever unit test para tooltip do Contribution_Graph
+    - Simular evento `mousemove` sobre uma barra do SVG
+    - Verificar que o tooltip exibe número de commits e período correspondente
+    - _Requirements: 3.3_
+
+- [x] 10. Implementar componente `renderProgressTracker`
+  - [x] 10.1 Implementar `calculateProgress(modules)` e `renderProgressTracker(modules)` em `docs/showcase/components/progressTracker.js`
+    - `calculateProgress` retorna `(módulos com status "done" / total) * 100`
+    - `renderProgressTracker` exibe badge de status por módulo (`done`, `in_progress`, `planned`) e barra de progresso geral
+    - Status manual do `config.json` tem prioridade absoluta — não inferir status de outras fontes
+    - _Requirements: 4.1, 4.2, 4.3, 4.4_
+
+  - [ ]* 10.2 Escrever property test — label e status de cada módulo (P7)
+    - **Property 7: Progress_Tracker renderiza label e status de cada módulo**
+    - **Validates: Requirements 4.1, 4.2**
+    - Usar `fc.array(fc.record({ id: fc.string(), label: fc.string({ minLength: 1 }), status: fc.constantFrom("done", "in_progress", "planned") }), { minLength: 1 })`
+    - Verificar que o HTML contém o `label` e uma representação visual do `status` de cada módulo
+
+  - [ ]* 10.3 Escrever property test — cálculo de percentual (P8)
+    - **Property 8: calculateProgress retorna a porcentagem correta de módulos concluídos**
+    - **Validates: Requirements 4.3**
+    - Usar `fc.array(moduleConfigArb, { minLength: 1 })`
+    - Verificar que o resultado é exatamente `(count("done") / total) * 100`
+
+  - [ ]* 10.4 Escrever property test — prioridade do status manual (P9)
+    - **Property 9: Status manual tem prioridade absoluta no Progress_Tracker**
+    - **Validates: Requirements 4.4**
+    - Usar `moduleConfigArb` com status explícito
+    - Verificar que o status exibido sempre iguala o valor configurado
+
+- [x] 11. Implementar componente `renderTeam`
+  - [x] 11.1 Implementar `renderTeam(members, avatars)` em `docs/showcase/components/team.js`
+    - Renderizar nome e link `https://github.com/{member.github}` para cada membro
+    - Quando o username está no mapa `avatars`, usar a URL fornecida como `src` do `<img>`
+    - Quando o username está ausente do mapa `avatars`, usar caminho de avatar padrão como `src`
+    - Adicionar `alt` descritivo em todos os elementos `<img>`
+    - _Requirements: 6.1, 6.2, 6.3_
+
+  - [ ]* 11.2 Escrever property test — nome e link GitHub de cada membro (P12)
+    - **Property 12: renderTeam exibe nome e link GitHub de cada membro**
+    - **Validates: Requirements 6.1**
+    - Usar `fc.array(fc.record({ name: fc.string({ minLength: 1 }), github: fc.string({ minLength: 1 }) }), { minLength: 1 })`
+    - Verificar que o HTML contém cada `name` e um anchor com `href` igual a `https://github.com/{github}`
+
+  - [ ]* 11.3 Escrever property test — avatar presente (P13)
+    - **Property 13: Avatar do membro é exibido quando disponível**
+    - **Validates: Requirements 6.2**
+    - Usar `teamMemberArb` + `fc.webUrl()` para gerar URL de avatar
+    - Verificar que o `<img>` tem `src` igual à URL fornecida no mapa
+
+  - [ ]* 11.4 Escrever property test — avatar padrão quando ausente (P14)
+    - **Property 14: Avatar padrão é exibido quando API não está disponível**
+    - **Validates: Requirements 6.3**
+    - Usar `teamMemberArb` com mapa de avatares vazio
+    - Verificar que o `<img>` tem `src` igual ao caminho do avatar padrão
+
+- [x] 12. Checkpoint — Verificar todos os componentes de UI
+  - Garantir que todos os testes de componentes passam
+  - Verificar renderização visual abrindo `index.html` localmente com dados mockados
+  - Perguntar ao usuário se há dúvidas antes de prosseguir para a integração
+
+- [x] 13. Integrar componentes em `app.js`
+  - [x] 13.1 Implementar o fluxo de inicialização em `app.js`
+    - Carregar `config.json` via `loadConfig()` ao iniciar
+    - Para cada chamada à `ApiClient`, consultar `CacheStore` antes de fazer fetch; usar cache se válido (< 1 hora)
+    - Chamar `renderHero`, `renderTechStack`, `renderProgressTracker` e `renderTeam` com dados do `config.json` imediatamente (sem esperar API)
+    - Chamar `renderStats` e `renderContributionGraph` com dados da API (ou cache); passar `stale=true` quando cache estiver desatualizado
+    - Em caso de falha na API com cache vazio, chamar `renderStats(null, false)` para exibir estado de erro
+    - _Requirements: 2.6, 2.7, 8.2_
+
+  - [ ]* 13.2 Escrever smoke test de integração
+    - Mockar `fetch` para retornar dados realistas do repositório Tokemize
+    - Verificar que todos os componentes são renderizados sem erros no DOM
+    - _Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 3.1, 4.1, 5.1, 6.1_
+
+- [x] 14. Implementar estilos responsivos e acessibilidade
+  - [x] 14.1 Implementar layout responsivo em `style.css`
+    - Garantir renderização correta em 1280×720, 1920×1080, 2560×1440 e largura mínima de 375px usando media queries
+    - Implementar paleta de cores com razão de contraste ≥ 4.5:1 entre texto e fundo (WCAG 2.1 AA)
+    - Otimizar assets para carregamento ≤ 3 segundos em 10 Mbps (sem imagens pesadas, CSS/JS minificados no build)
+    - _Requirements: 7.1, 7.2, 7.3, 7.4_
+
+  - [ ]* 14.2 Escrever unit test de contraste de cores WCAG
+    - Verificar cada par texto/fundo definido no CSS usando fórmula de luminância relativa
+    - Confirmar razão de contraste ≥ 4.5:1 para todos os pares
+    - _Requirements: 7.3_
+
+- [x] 15. Criar o workflow de deploy (`deploy.yml`)
+  - Criar `.github/workflows/deploy.yml` conforme o design:
+    - Trigger: `push` na branch `main`
+    - Job com `timeout-minutes: 5` e `permissions: contents: write`
+    - Steps: `actions/checkout@v4` → `peaceiris/actions-gh-pages@v4` com `publish_dir: ./docs/showcase` e `keep_files: false`
+  - Garantir que falha em qualquer step termina o job com código não-zero sem sobrescrever `gh-pages`
+  - _Requirements: 1.1, 1.2, 1.3, 1.4_
+
+- [x] 16. Checkpoint final — Garantir que tudo está integrado
+  - Garantir que todos os testes passam (`npx vitest run` em `docs/showcase/`)
+  - Verificar que `config.json` com campos ausentes exibe `DEFAULT_CONFIG` e emite `console.warn`
+  - Verificar que o workflow `deploy.yml` está sintaticamente correto (lint com `actionlint` ou validação manual)
+  - Perguntar ao usuário se há dúvidas antes de considerar a implementação concluída
+
+## Notes
+
+- Tarefas marcadas com `*` são opcionais e podem ser puladas para um MVP mais rápido
+- Cada tarefa referencia requisitos específicos para rastreabilidade
+- Os checkpoints garantem validação incremental antes de avançar para a próxima fase
+- Os property tests usam fast-check com mínimo de 100 iterações por propriedade (`numRuns: 100`)
+- Cada teste PBT deve incluir o comentário: `// Feature: github-pages-project-showcase, Property N: <texto>`
+- O site é um Static_Site puro — nenhuma dependência de backend é permitida
+- O `config.json` é a única fonte de verdade para conteúdo configurável; status manual de módulos tem prioridade absoluta

--- a/docs/showcase/.gitignore
+++ b/docs/showcase/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+coverage/
+.vite/

--- a/docs/showcase/__tests__/apiClient.test.js
+++ b/docs/showcase/__tests__/apiClient.test.js
@@ -1,0 +1,90 @@
+// Feature: github-pages-project-showcase — Unit tests para ApiClient
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import { fetchRepoStats, fetchAvatarUrl, ApiError } from '../apiClient.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Cria um mock de fetch que retorna dados com Link header para paginação */
+function mockFetchWithLink(data, total = 1) {
+  const linkHeader = total > 1
+    ? `<https://api.github.com/resource?page=${total}>; rel="last"`
+    : null;
+
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+    ok: true,
+    status: 200,
+    headers: {
+      get: (name) => name === 'Link' ? linkHeader : null,
+    },
+    json: async () => data,
+  }));
+}
+
+describe('ApiClient', () => {
+  test('fetchRepoStats — resposta bem-sucedida retorna RepoStats corretamente mapeado', async () => {
+    // Mock: 5 commits, 2 open PRs, 3 closed PRs, 4 contributors, 6 branches
+    const lastCommitDate = '2025-04-01T10:00:00Z';
+    let callCount = 0;
+
+    vi.stubGlobal('fetch', vi.fn().mockImplementation((url) => {
+      callCount++;
+      let total = 1;
+      if (url.includes('/commits')) total = 5;
+      if (url.includes('state=open')) total = 2;
+      if (url.includes('state=closed')) total = 3;
+      if (url.includes('/contributors')) total = 4;
+      if (url.includes('/branches')) total = 6;
+
+      const linkHeader = total > 1
+        ? `<https://api.github.com/resource?page=${total}>; rel="last"`
+        : null;
+
+      const data = url.includes('/commits') && url.includes('sha=main')
+        ? [{ commit: { author: { date: lastCommitDate } } }]
+        : [];
+
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (name) => name === 'Link' ? linkHeader : null },
+        json: async () => data,
+      });
+    }));
+
+    const stats = await fetchRepoStats('owner', 'repo', 8000);
+
+    expect(stats.totalCommits).toBe(5);
+    expect(stats.openPRs).toBe(2);
+    expect(stats.closedPRs).toBe(3);
+    expect(stats.contributors).toBe(4);
+    expect(stats.activeBranches).toBe(6);
+    expect(stats.lastCommitAt).toBe(lastCommitDate);
+  });
+
+  test('fetchRepoStats — HTTP 4xx lança ApiError com status e endpoint corretos', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: false,
+      status: 403,
+      headers: { get: () => null },
+      json: async () => ({ message: 'Forbidden' }),
+    }));
+
+    await expect(fetchRepoStats('owner', 'repo', 8000)).rejects.toThrow(ApiError);
+    await expect(fetchRepoStats('owner', 'repo', 8000)).rejects.toMatchObject({ status: 403 });
+  });
+
+  test('fetchAvatarUrl — retorna avatar_url do usuário', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => null },
+      json: async () => ({ avatar_url: 'https://avatars.githubusercontent.com/u/123' }),
+    }));
+
+    const url = await fetchAvatarUrl('testuser', 8000);
+    expect(url).toBe('https://avatars.githubusercontent.com/u/123');
+  });
+});

--- a/docs/showcase/__tests__/cacheStore.test.js
+++ b/docs/showcase/__tests__/cacheStore.test.js
@@ -1,0 +1,55 @@
+// Feature: github-pages-project-showcase, Property 3: CacheStore.isStale respeita o TTL de 1 hora
+
+import { describe, test, expect, beforeEach, vi } from 'vitest';
+import * as fc from 'fast-check';
+import { CacheStore, DEFAULT_TTL } from '../cacheStore.js';
+
+describe('CacheStore', () => {
+  let store;
+
+  beforeEach(() => {
+    store = new CacheStore();
+    localStorage.clear();
+  });
+
+  test('P3 — isStale respeita o TTL de 1 hora', () => {
+    // Feature: github-pages-project-showcase, Property 3: isStale retorna true sse (Date.now() - t) > maxAgeMs
+    fc.assert(
+      fc.property(
+        fc.integer({ min: 0, max: DEFAULT_TTL * 2 }),
+        (ageMs) => {
+          const now = Date.now();
+          const timestamp = now - ageMs;
+
+          // Inserir entrada manualmente no localStorage com timestamp controlado
+          const key = 'tokemize_cache_test_p3';
+          localStorage.setItem(key, JSON.stringify({ data: 'x', timestamp }));
+
+          const result = store.isStale('test_p3', DEFAULT_TTL);
+          const expected = ageMs > DEFAULT_TTL;
+
+          return result === expected;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test('get retorna null para chave inexistente', () => {
+    expect(store.get('nao_existe')).toBeNull();
+  });
+
+  test('set e get fazem round-trip', () => {
+    store.set('chave', { valor: 42 });
+    expect(store.get('chave')).toEqual({ valor: 42 });
+  });
+
+  test('isStale retorna true para chave inexistente', () => {
+    expect(store.isStale('nao_existe', DEFAULT_TTL)).toBe(true);
+  });
+
+  test('isStale retorna false para entrada recém-criada', () => {
+    store.set('recente', 'dado');
+    expect(store.isStale('recente', DEFAULT_TTL)).toBe(false);
+  });
+});

--- a/docs/showcase/__tests__/configLoader.test.js
+++ b/docs/showcase/__tests__/configLoader.test.js
@@ -1,0 +1,97 @@
+// Feature: github-pages-project-showcase, Property 15: loadConfig faz round-trip completo de AppConfig
+// Feature: github-pages-project-showcase, Property 16: loadConfig retorna DEFAULT_CONFIG para entradas inválidas
+
+import { describe, test, expect, vi, afterEach } from 'vitest';
+import * as fc from 'fast-check';
+import { loadConfig, DEFAULT_CONFIG } from '../configLoader.js';
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+/** Cria um mock de fetch que retorna o body fornecido */
+function mockFetch(body, status = 200) {
+  const response = {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => (typeof body === 'string' ? JSON.parse(body) : body),
+  };
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+}
+
+/** Cria um mock de fetch que retorna JSON malformado */
+function mockFetchMalformed() {
+  const response = {
+    ok: true,
+    status: 200,
+    json: async () => { throw new SyntaxError('Unexpected token'); },
+  };
+  vi.stubGlobal('fetch', vi.fn().mockResolvedValue(response));
+}
+
+const techItemArb = fc.record({
+  name: fc.string({ minLength: 1 }),
+  url:  fc.webUrl(),
+});
+
+const moduleArb = fc.record({
+  id:     fc.string({ minLength: 1 }),
+  label:  fc.string({ minLength: 1 }),
+  status: fc.constantFrom('done', 'in_progress', 'planned'),
+});
+
+const teamMemberArb = fc.record({
+  name:   fc.string({ minLength: 1 }),
+  github: fc.string({ minLength: 1 }),
+});
+
+const appConfigArb = fc.record({
+  projectName: fc.string({ minLength: 1 }),
+  tagline:     fc.string({ minLength: 1 }),
+  modules:     fc.array(moduleArb, { minLength: 1 }),
+  team:        fc.array(teamMemberArb, { minLength: 1 }),
+  links:       fc.record({ repo: fc.webUrl() }),
+});
+
+describe('ConfigLoader', () => {
+  test('P15 — loadConfig faz round-trip completo de AppConfig', async () => {
+    // Feature: github-pages-project-showcase, Property 15
+    await fc.assert(
+      fc.asyncProperty(appConfigArb, async (config) => {
+        mockFetch(config);
+        const result = await loadConfig();
+        return (
+          result.projectName === config.projectName &&
+          result.tagline     === config.tagline &&
+          result.modules.length === config.modules.length &&
+          result.team.length    === config.team.length
+        );
+      }),
+      { numRuns: 50 },
+    );
+  });
+
+  test('P16 — loadConfig retorna DEFAULT_CONFIG para entradas inválidas', async () => {
+    // Feature: github-pages-project-showcase, Property 16
+    // Caso 1: HTTP 404
+    mockFetch('', 404);
+    let result = await loadConfig();
+    expect(result).toEqual(DEFAULT_CONFIG);
+
+    // Caso 2: JSON malformado
+    mockFetchMalformed();
+    result = await loadConfig();
+    expect(result).toEqual(DEFAULT_CONFIG);
+
+    // Caso 3: Campos obrigatórios faltando
+    mockFetch({ projectName: 'X' }); // falta tagline, modules, team, links
+    result = await loadConfig();
+    expect(result).toEqual(DEFAULT_CONFIG);
+  });
+
+  test('loadConfig retorna DEFAULT_CONFIG quando fetch lança erro de rede', async () => {
+    vi.stubGlobal('fetch', vi.fn().mockRejectedValue(new TypeError('Network error')));
+    const result = await loadConfig();
+    expect(result).toEqual(DEFAULT_CONFIG);
+  });
+});

--- a/docs/showcase/__tests__/renderContributionGraph.test.js
+++ b/docs/showcase/__tests__/renderContributionGraph.test.js
@@ -1,0 +1,117 @@
+// Feature: github-pages-project-showcase, Property 4: Contribution_Graph cobre as últimas 13 semanas
+// Feature: github-pages-project-showcase, Property 5: Contribution_Graph atribui cores distintas por autor
+// Feature: github-pages-project-showcase, Property 6: Contribution_Graph SVG possui aria-label não vazio
+
+import { describe, test, expect, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { renderContributionGraph, getAuthorColors } from '../components/contributionGraph.js';
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <div id="contribution-graph-container"></div>
+    <div id="graph-tooltip" class="graph-tooltip"></div>
+  `;
+}
+
+/** Gera uma data ISO no formato YYYY-MM-DD */
+const isoDateArb = fc.date({
+  min: new Date('2024-01-01'),
+  max: new Date('2026-12-31'),
+}).map(d => d.toISOString().slice(0, 10));
+
+const weeklyActivityArb = fc.record({
+  week:         isoDateArb,
+  totalCommits: fc.nat({ max: 50 }),
+  byAuthor:     fc.dictionary(
+    fc.stringMatching(/^[a-zA-Z0-9-]{1,15}$/),
+    fc.nat({ max: 20 }),
+  ),
+});
+
+/**
+ * Filtra atividade para as últimas 13 semanas — replica a lógica do componente.
+ */
+function filterLast13Weeks(activity) {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 90);
+  return activity.filter(w => new Date(w.week + 'T00:00:00') >= cutoff);
+}
+
+describe('renderContributionGraph', () => {
+  beforeEach(setupDOM);
+
+  test('P4 — cobre exatamente as últimas 13 semanas', () => {
+    // Feature: github-pages-project-showcase, Property 4
+    fc.assert(
+      fc.property(
+        fc.array(weeklyActivityArb, { minLength: 0, maxLength: 20 }),
+        (activity) => {
+          const filtered = filterLast13Weeks(activity);
+          // Todas as semanas filtradas devem estar dentro dos últimos 90 dias
+          const cutoff = new Date();
+          cutoff.setDate(cutoff.getDate() - 90);
+          return filtered.every(w => new Date(w.week + 'T00:00:00') >= cutoff);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P5 — atribui cores distintas por autor', () => {
+    // Feature: github-pages-project-showcase, Property 5
+    fc.assert(
+      fc.property(
+        fc.array(
+          fc.stringMatching(/^[a-zA-Z0-9-]{1,15}$/),
+          { minLength: 1, maxLength: 12 },
+        ).map(arr => [...new Set(arr)]).filter(arr => arr.length > 0),
+        (authors) => {
+          const colorMap = getAuthorColors(authors);
+          const colors = [...colorMap.values()];
+          const uniqueColors = new Set(colors);
+          // Cada autor deve ter uma cor; autores distintos devem ter cores distintas
+          // (até o limite da paleta de 12 cores)
+          const effectiveAuthors = authors.slice(0, 12);
+          return colorMap.size === authors.length &&
+                 uniqueColors.size === Math.min(authors.length, 12);
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P6 — SVG possui aria-label não vazio', () => {
+    // Feature: github-pages-project-showcase, Property 6
+    fc.assert(
+      fc.property(
+        fc.array(weeklyActivityArb, { minLength: 0, maxLength: 13 }),
+        (activity) => {
+          setupDOM();
+          renderContributionGraph(activity);
+          const svg = document.querySelector('#contribution-graph-container svg');
+          if (!svg) return activity.length === 0; // sem dados, pode não renderizar SVG
+          const ariaLabel = svg.getAttribute('aria-label');
+          return typeof ariaLabel === 'string' && ariaLabel.length > 0;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test('tooltip — exibe commits e período ao passar o cursor', () => {
+    const activity = [
+      { week: '2025-01-06', totalCommits: 7, byAuthor: {} },
+    ];
+    setupDOM();
+    renderContributionGraph(activity);
+
+    const rect = document.querySelector('rect');
+    expect(rect).not.toBeNull();
+
+    // Simula mouseenter
+    rect.dispatchEvent(new MouseEvent('mouseenter', { bubbles: true }));
+    const tooltip = document.getElementById('graph-tooltip');
+    expect(tooltip.textContent).toContain('7');
+    expect(tooltip.textContent).toContain('2025-01-06');
+  });
+});

--- a/docs/showcase/__tests__/renderHero.test.js
+++ b/docs/showcase/__tests__/renderHero.test.js
@@ -1,0 +1,49 @@
+// Feature: github-pages-project-showcase, Property 10: renderHero exibe todos os campos da hero section
+
+import { describe, test, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { renderHero } from '../components/hero.js';
+
+function setupDOM() {
+  document.body.innerHTML = `
+    <h1 id="hero-title"></h1>
+    <p class="hero-tagline"></p>
+    <ul id="problems-list"></ul>
+    <div id="pipeline-container"></div>
+  `;
+}
+
+const appConfigArb = fc.record({
+  projectName: fc.string({ minLength: 1, maxLength: 30 }),
+  tagline:     fc.string({ minLength: 1, maxLength: 80 }),
+  problems:    fc.array(fc.string({ minLength: 1, maxLength: 50 }), { minLength: 1, maxLength: 5 }),
+  pipeline:    fc.array(fc.string({ minLength: 1, maxLength: 30 }), { minLength: 2, maxLength: 5 }),
+});
+
+describe('renderHero', () => {
+  beforeEach(setupDOM);
+
+  test('P10 — exibe todos os campos de conteúdo da hero section', () => {
+    // Feature: github-pages-project-showcase, Property 10
+    fc.assert(
+      fc.property(appConfigArb, (config) => {
+        setupDOM();
+        renderHero(config);
+
+        // Usa textContent dos elementos para evitar falsos negativos com escape HTML
+        const titleText    = document.getElementById('hero-title')?.textContent ?? '';
+        const taglineText  = document.querySelector('.hero-tagline')?.textContent ?? '';
+        const problemTexts = [...document.querySelectorAll('#problems-list li')].map(el => el.textContent);
+        const pipelineTexts = [...document.querySelectorAll('#pipeline-container .pipeline-step')].map(el => el.textContent);
+
+        const hasProjectName = titleText === config.projectName;
+        const hasTagline     = taglineText === config.tagline;
+        const hasAllProblems = config.problems.every(p => problemTexts.includes(p));
+        const hasAllSteps    = config.pipeline.every(s => pipelineTexts.includes(s));
+
+        return hasProjectName && hasTagline && hasAllProblems && hasAllSteps;
+      }),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/docs/showcase/__tests__/renderProgressTracker.test.js
+++ b/docs/showcase/__tests__/renderProgressTracker.test.js
@@ -1,0 +1,84 @@
+// Feature: github-pages-project-showcase, Property 7: Progress_Tracker renderiza label e status de cada módulo
+// Feature: github-pages-project-showcase, Property 8: calculateProgress retorna a porcentagem correta
+// Feature: github-pages-project-showcase, Property 9: Status manual tem prioridade absoluta
+
+import { describe, test, expect, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { renderProgressTracker, calculateProgress } from '../components/progressTracker.js';
+
+function setupDOM() {
+  document.body.innerHTML = '<div id="progress-container"></div>';
+}
+
+const statusArb = fc.constantFrom('done', 'in_progress', 'planned');
+
+const moduleConfigArb = fc.record({
+  id:     fc.string({ minLength: 1, maxLength: 20 }),
+  label:  fc.string({ minLength: 1, maxLength: 30 }),
+  status: statusArb,
+});
+
+describe('renderProgressTracker', () => {
+  beforeEach(setupDOM);
+
+  test('P7 — renderiza label e status de cada módulo', () => {
+    // Feature: github-pages-project-showcase, Property 7
+    fc.assert(
+      fc.property(fc.array(moduleConfigArb, { minLength: 1, maxLength: 10 }), (modules) => {
+        setupDOM();
+        renderProgressTracker(modules);
+
+        // Usa textContent dos elementos para evitar falsos negativos com escape HTML
+        const labelEls = [...document.querySelectorAll('.module-label')].map(el => el.textContent);
+        const badgeEls = [...document.querySelectorAll('.module-badge')];
+
+        const allLabelsPresent = modules.every(mod => labelEls.includes(mod.label));
+        const allStatusesPresent = modules.every(mod =>
+          badgeEls.some(el => el.classList.contains(`module-badge--${mod.status}`))
+        );
+
+        return allLabelsPresent && allStatusesPresent;
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P8 — calculateProgress retorna a porcentagem correta de módulos concluídos', () => {
+    // Feature: github-pages-project-showcase, Property 8
+    fc.assert(
+      fc.property(fc.array(moduleConfigArb, { minLength: 1, maxLength: 20 }), (modules) => {
+        const doneCount = modules.filter(m => m.status === 'done').length;
+        const expected = (doneCount / modules.length) * 100;
+        const result = calculateProgress(modules);
+        return Math.abs(result - expected) < 0.0001;
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P9 — status manual tem prioridade absoluta no Progress_Tracker', () => {
+    // Feature: github-pages-project-showcase, Property 9
+    fc.assert(
+      fc.property(moduleConfigArb, (mod) => {
+        setupDOM();
+        renderProgressTracker([mod]);
+        const html = document.getElementById('progress-container').innerHTML;
+        // O badge deve conter a classe correspondente ao status configurado
+        return html.includes(`module-badge--${mod.status}`);
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('calculateProgress retorna 0 para array vazio', () => {
+    expect(calculateProgress([])).toBe(0);
+  });
+
+  test('calculateProgress retorna 100 quando todos os módulos estão done', () => {
+    const modules = [
+      { id: 'a', label: 'A', status: 'done' },
+      { id: 'b', label: 'B', status: 'done' },
+    ];
+    expect(calculateProgress(modules)).toBe(100);
+  });
+});

--- a/docs/showcase/__tests__/renderStats.test.js
+++ b/docs/showcase/__tests__/renderStats.test.js
@@ -1,0 +1,70 @@
+// Feature: github-pages-project-showcase, Property 1: Stats_Widget renderiza todos os campos de RepoStats
+// Feature: github-pages-project-showcase, Property 2: Indicador de dados desatualizados é exibido quando stale=true
+
+import { describe, test, expect, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { renderStats } from '../components/stats.js';
+
+function setupDOM() {
+  document.body.innerHTML = '<div id="stats-grid"></div>';
+}
+
+const repoStatsArb = fc.record({
+  totalCommits:   fc.nat(),
+  openPRs:        fc.nat(),
+  closedPRs:      fc.nat(),
+  contributors:   fc.nat(),
+  activeBranches: fc.nat(),
+  lastCommitAt:   fc.date({ min: new Date('2020-01-01'), max: new Date('2026-12-31') })
+                    .map(d => d.toISOString()),
+});
+
+describe('renderStats', () => {
+  beforeEach(setupDOM);
+
+  test('P1 — renderiza todos os campos de RepoStats', () => {
+    // Feature: github-pages-project-showcase, Property 1
+    fc.assert(
+      fc.property(repoStatsArb, (stats) => {
+        setupDOM();
+        renderStats(stats, false);
+        const html = document.getElementById('stats-grid').innerHTML;
+
+        return (
+          html.includes(String(stats.totalCommits)) &&
+          html.includes(String(stats.openPRs)) &&
+          html.includes(String(stats.closedPRs)) &&
+          html.includes(String(stats.contributors)) &&
+          html.includes(String(stats.activeBranches))
+        );
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P2 — indicador de dados desatualizados é exibido quando stale=true', () => {
+    // Feature: github-pages-project-showcase, Property 2
+    fc.assert(
+      fc.property(repoStatsArb, (stats) => {
+        setupDOM();
+        renderStats(stats, true);
+        const grid = document.getElementById('stats-grid');
+        const staleEl = grid.querySelector('[data-stale="true"]');
+        return staleEl !== null;
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('renderStats(null) exibe estado de erro', () => {
+    renderStats(null, false);
+    const html = document.getElementById('stats-grid').innerHTML;
+    expect(html).toContain('stats-error');
+  });
+
+  test('stale=false não exibe indicador de desatualização', () => {
+    renderStats({ totalCommits: 1, openPRs: 0, closedPRs: 0, contributors: 1, activeBranches: 1, lastCommitAt: new Date().toISOString() }, false);
+    const staleEl = document.querySelector('[data-stale="true"]');
+    expect(staleEl).toBeNull();
+  });
+});

--- a/docs/showcase/__tests__/renderTeam.test.js
+++ b/docs/showcase/__tests__/renderTeam.test.js
@@ -1,0 +1,84 @@
+// Feature: github-pages-project-showcase, Property 12: renderTeam exibe nome e link GitHub de cada membro
+// Feature: github-pages-project-showcase, Property 13: Avatar do membro é exibido quando disponível
+// Feature: github-pages-project-showcase, Property 14: Avatar padrão é exibido quando API não está disponível
+
+import { describe, test, expect, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { renderTeam } from '../components/team.js';
+
+const DEFAULT_AVATAR = './assets/default-avatar.svg';
+
+function setupDOM() {
+  document.body.innerHTML = '<ul id="team-list"></ul>';
+}
+
+const teamMemberArb = fc.record({
+  name:   fc.string({ minLength: 1, maxLength: 40 }),
+  github: fc.stringMatching(/^[a-zA-Z0-9-]{1,20}$/),
+});
+
+describe('renderTeam', () => {
+  beforeEach(setupDOM);
+
+  test('P12 — exibe nome e link GitHub de cada membro', () => {
+    // Feature: github-pages-project-showcase, Property 12
+    fc.assert(
+      fc.property(
+        fc.array(teamMemberArb, { minLength: 1, maxLength: 6 }),
+        (members) => {
+          setupDOM();
+          renderTeam(members, new Map());
+
+          const nameEls = [...document.querySelectorAll('.team-name')].map(el => el.textContent);
+          const linkEls = [...document.querySelectorAll('.team-github-link')];
+
+          return members.every(m => {
+            const hasName = nameEls.includes(m.name);
+            const hasLink = linkEls.some(a =>
+              a.getAttribute('href') === `https://github.com/${m.github}`
+            );
+            return hasName && hasLink;
+          });
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P13 — avatar do membro é exibido quando disponível', () => {
+    // Feature: github-pages-project-showcase, Property 13
+    fc.assert(
+      fc.property(
+        teamMemberArb,
+        fc.webUrl(),
+        (member, avatarUrl) => {
+          setupDOM();
+          const avatars = new Map([[member.github, avatarUrl]]);
+          renderTeam([member], avatars);
+
+          const img = document.querySelector('.team-avatar');
+          return img !== null && img.getAttribute('src') === avatarUrl;
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+
+  test('P14 — avatar padrão é exibido quando API não está disponível', () => {
+    // Feature: github-pages-project-showcase, Property 14
+    fc.assert(
+      fc.property(teamMemberArb, (member) => {
+        setupDOM();
+        renderTeam([member], new Map());
+
+        const img = document.querySelector('.team-avatar');
+        return img !== null && img.getAttribute('src') === DEFAULT_AVATAR;
+      }),
+      { numRuns: 100 },
+    );
+  });
+
+  test('renderTeam com lista vazia não lança erro', () => {
+    expect(() => renderTeam([], new Map())).not.toThrow();
+  });
+});

--- a/docs/showcase/__tests__/renderTechStack.test.js
+++ b/docs/showcase/__tests__/renderTechStack.test.js
@@ -1,0 +1,40 @@
+// Feature: github-pages-project-showcase, Property 11: renderTechStack exibe nome e link de cada tecnologia
+
+import { describe, test, beforeEach } from 'vitest';
+import * as fc from 'fast-check';
+import { renderTechStack } from '../components/techStack.js';
+
+function setupDOM() {
+  document.body.innerHTML = '<ul id="tech-stack-list"></ul>';
+}
+
+const techItemArb = fc.record({
+  name: fc.string({ minLength: 1, maxLength: 30 }),
+  url:  fc.webUrl(),
+});
+
+describe('renderTechStack', () => {
+  beforeEach(setupDOM);
+
+  test('P11 — exibe nome e link de cada tecnologia', () => {
+    // Feature: github-pages-project-showcase, Property 11
+    fc.assert(
+      fc.property(
+        fc.array(techItemArb, { minLength: 1, maxLength: 8 }),
+        (techStack) => {
+          setupDOM();
+          renderTechStack({ techStack });
+
+          const anchors = [...document.querySelectorAll('#tech-stack-list a')];
+
+          return techStack.every(tech => {
+            return anchors.some(a =>
+              a.textContent === tech.name && a.getAttribute('href') === tech.url
+            );
+          });
+        },
+      ),
+      { numRuns: 100 },
+    );
+  });
+});

--- a/docs/showcase/apiClient.js
+++ b/docs/showcase/apiClient.js
@@ -1,0 +1,206 @@
+/**
+ * ApiClient — abstração sobre a GitHub REST API.
+ * Todas as chamadas usam fetch nativo com AbortController para timeout.
+ */
+
+const BASE_URL = 'https://api.github.com';
+
+// ---------------------------------------------------------------------------
+// ApiError
+// ---------------------------------------------------------------------------
+
+/**
+ * Erro lançado quando uma chamada à GitHub API falha (HTTP ≥ 400 ou timeout).
+ */
+export class ApiError extends Error {
+  /**
+   * @param {number} status    - Código HTTP (ou 0 para timeout/abort)
+   * @param {string} endpoint  - URL do endpoint que falhou
+   * @param {string} message   - Mensagem descritiva
+   */
+  constructor(status, endpoint, message) {
+    super(message);
+    this.name = 'ApiError';
+    this.status = status;
+    this.endpoint = endpoint;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Helpers internos
+// ---------------------------------------------------------------------------
+
+/**
+ * Executa um fetch com timeout via AbortController.
+ * Lança ApiError em caso de timeout ou status HTTP ≥ 400.
+ *
+ * @param {string} url
+ * @param {number} timeout - ms
+ * @returns {Promise<Response>}
+ */
+async function fetchWithTimeout(url, timeout) {
+  const controller = new AbortController();
+  const timerId = setTimeout(() => controller.abort(), timeout);
+
+  let response;
+  try {
+    response = await fetch(url, { signal: controller.signal });
+  } catch (err) {
+    clearTimeout(timerId);
+    if (err.name === 'AbortError') {
+      throw new ApiError(0, url, `Request timed out after ${timeout}ms: ${url}`);
+    }
+    throw new ApiError(0, url, `Network error: ${err.message}`);
+  }
+
+  clearTimeout(timerId);
+
+  if (!response.ok) {
+    throw new ApiError(response.status, url, `HTTP ${response.status} from ${url}`);
+  }
+
+  return response;
+}
+
+/**
+ * Extrai o total de itens a partir do header Link da GitHub API.
+ * Técnica: per_page=1 + ler o número da última página no rel="last".
+ *
+ * @param {Response} response
+ * @returns {number}
+ */
+function parseTotalFromLinkHeader(response) {
+  const linkHeader = response.headers.get('Link');
+  if (!linkHeader) return 1;
+  const match = linkHeader.match(/<[^>]*[?&]page=(\d+)[^>]*>;\s*rel="last"/);
+  if (!match) return 1;
+  return parseInt(match[1], 10);
+}
+
+/**
+ * Constrói a URL completa para a GitHub API.
+ *
+ * @param {string} path
+ * @param {Record<string, string|number>} [params]
+ * @returns {string}
+ */
+function buildUrl(path, params = {}) {
+  const url = new URL(`${BASE_URL}${path}`);
+  for (const [key, value] of Object.entries(params)) {
+    url.searchParams.set(key, String(value));
+  }
+  return url.toString();
+}
+
+// ---------------------------------------------------------------------------
+// fetchRepoStats
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} RepoStats
+ * @property {number} totalCommits
+ * @property {number} openPRs
+ * @property {number} closedPRs
+ * @property {number} contributors
+ * @property {number} activeBranches
+ * @property {string} lastCommitAt   - ISO 8601
+ */
+
+/**
+ * Busca estatísticas do repositório na GitHub API.
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} [timeout=8000]
+ * @returns {Promise<RepoStats>}
+ */
+export async function fetchRepoStats(owner, repo, timeout = 8000) {
+  const base = `/repos/${owner}/${repo}`;
+
+  const commitsUrl      = buildUrl(`${base}/commits`,      { per_page: 1 });
+  const openPRsUrl      = buildUrl(`${base}/pulls`,        { state: 'open',   per_page: 1 });
+  const closedPRsUrl    = buildUrl(`${base}/pulls`,        { state: 'closed', per_page: 1 });
+  const contributorsUrl = buildUrl(`${base}/contributors`, { per_page: 1 });
+  const branchesUrl     = buildUrl(`${base}/branches`,     { per_page: 1 });
+  const lastCommitUrl   = buildUrl(`${base}/commits`,      { sha: 'main', per_page: 1 });
+
+  const [
+    commitsRes,
+    openPRsRes,
+    closedPRsRes,
+    contributorsRes,
+    branchesRes,
+    lastCommitRes,
+  ] = await Promise.all([
+    fetchWithTimeout(commitsUrl,      timeout),
+    fetchWithTimeout(openPRsUrl,      timeout),
+    fetchWithTimeout(closedPRsUrl,    timeout),
+    fetchWithTimeout(contributorsUrl, timeout),
+    fetchWithTimeout(branchesUrl,     timeout),
+    fetchWithTimeout(lastCommitUrl,   timeout),
+  ]);
+
+  const totalCommits   = parseTotalFromLinkHeader(commitsRes);
+  const openPRs        = parseTotalFromLinkHeader(openPRsRes);
+  const closedPRs      = parseTotalFromLinkHeader(closedPRsRes);
+  const contributors   = parseTotalFromLinkHeader(contributorsRes);
+  const activeBranches = parseTotalFromLinkHeader(branchesRes);
+
+  const lastCommitData = await lastCommitRes.json();
+  const lastCommitAt = Array.isArray(lastCommitData) && lastCommitData.length > 0
+    ? lastCommitData[0]?.commit?.author?.date ?? new Date(0).toISOString()
+    : new Date(0).toISOString();
+
+  return { totalCommits, openPRs, closedPRs, contributors, activeBranches, lastCommitAt };
+}
+
+// ---------------------------------------------------------------------------
+// fetchCommitActivity
+// ---------------------------------------------------------------------------
+
+/**
+ * @typedef {Object} WeeklyActivity
+ * @property {string} week          - ISO date string do início da semana
+ * @property {number} totalCommits
+ * @property {Object} byAuthor      - Sempre vazio (a API não retorna por autor)
+ */
+
+/**
+ * Busca a atividade de commits das últimas 13 semanas.
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} [timeout=8000]
+ * @returns {Promise<WeeklyActivity[]>}
+ */
+export async function fetchCommitActivity(owner, repo, timeout = 8000) {
+  const url = buildUrl(`/repos/${owner}/${repo}/stats/commit_activity`);
+  const response = await fetchWithTimeout(url, timeout);
+  const data = await response.json();
+
+  if (!Array.isArray(data)) return [];
+
+  return data.slice(-13).map((entry) => ({
+    week: new Date(entry.week * 1000).toISOString().split('T')[0],
+    totalCommits: entry.total ?? 0,
+    byAuthor: {},
+  }));
+}
+
+// ---------------------------------------------------------------------------
+// fetchAvatarUrl
+// ---------------------------------------------------------------------------
+
+/**
+ * Busca a URL do avatar de um usuário do GitHub.
+ *
+ * @param {string} username
+ * @param {number} [timeout=8000]
+ * @returns {Promise<string>}
+ */
+export async function fetchAvatarUrl(username, timeout = 8000) {
+  const url = buildUrl(`/users/${username}`);
+  const response = await fetchWithTimeout(url, timeout);
+  const data = await response.json();
+  return data.avatar_url;
+}

--- a/docs/showcase/app.js
+++ b/docs/showcase/app.js
@@ -1,0 +1,168 @@
+/**
+ * app.js — Entry point da Showcase_Page do Tokemize
+ *
+ * Fluxo de inicialização:
+ * 1. Carregar config.json via loadConfig()
+ * 2. Renderizar seções estáticas IMEDIATAMENTE (hero, pipeline, techStack, progress, team)
+ *    sem esperar pela API
+ * 3. Para stats e contribution graph:
+ *    a. Verificar CacheStore antes de chamar a API
+ *    b. Se cache válido (< 1 hora): usar dados do cache, stale=false
+ *    c. Se cache stale: chamar API, atualizar cache, stale=false
+ *    d. Se API falhar com cache stale: usar cache, stale=true
+ *    e. Se API falhar sem cache: renderStats(null, false) — estado de erro
+ * 4. Para avatares da equipe:
+ *    a. Buscar avatares de todos os membros via fetchAvatarUrl
+ *    b. Montar Map<string, string> e re-renderizar equipe com avatares
+ *    c. Se falhar, manter renderização sem avatares (fallback já está no renderTeam)
+ *
+ * Requirements: 2.6, 2.7, 8.2
+ */
+
+import { loadConfig }          from './configLoader.js';
+import { CacheStore, DEFAULT_TTL } from './cacheStore.js';
+import { fetchRepoStats, fetchCommitActivity, fetchAvatarUrl } from './apiClient.js';
+
+import { renderHero }              from './components/hero.js';
+import { renderStats }             from './components/stats.js';
+import { renderContributionGraph } from './components/contributionGraph.js';
+import { renderProgressTracker }   from './components/progressTracker.js';
+import { renderTechStack }         from './components/techStack.js';
+import { renderTeam }              from './components/team.js';
+
+// Chaves de cache
+const CACHE_KEY_STATS    = 'repo_stats';
+const CACHE_KEY_ACTIVITY = 'commit_activity';
+
+const cache = new CacheStore();
+
+/**
+ * Carrega e renderiza as estatísticas do repositório.
+ * Consulta o CacheStore antes de chamar a API.
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} timeout
+ */
+async function loadAndRenderStats(owner, repo, timeout) {
+  const isStale = cache.isStale(CACHE_KEY_STATS, DEFAULT_TTL);
+
+  if (!isStale) {
+    // Cache válido — usar diretamente, sem chamar a API
+    const cached = cache.get(CACHE_KEY_STATS);
+    renderStats(cached, false);
+    return;
+  }
+
+  // Cache stale ou ausente — tentar a API
+  try {
+    const stats = await fetchRepoStats(owner, repo, timeout);
+    cache.set(CACHE_KEY_STATS, stats);
+    renderStats(stats, false);
+  } catch (err) {
+    // API falhou — verificar se há cache stale disponível
+    const cached = cache.get(CACHE_KEY_STATS);
+    if (cached !== null) {
+      // Cache stale disponível: exibir com indicador de desatualização
+      renderStats(cached, true);
+    } else {
+      // Sem cache e API falhou: exibir estado de erro
+      renderStats(null, false);
+    }
+  }
+}
+
+/**
+ * Carrega e renderiza o gráfico de contribuições.
+ * Consulta o CacheStore antes de chamar a API.
+ *
+ * @param {string} owner
+ * @param {string} repo
+ * @param {number} timeout
+ */
+async function loadAndRenderContributionGraph(owner, repo, timeout) {
+  const isStale = cache.isStale(CACHE_KEY_ACTIVITY, DEFAULT_TTL);
+
+  if (!isStale) {
+    // Cache válido — usar diretamente
+    const cached = cache.get(CACHE_KEY_ACTIVITY);
+    renderContributionGraph(cached);
+    return;
+  }
+
+  // Cache stale ou ausente — tentar a API
+  try {
+    const activity = await fetchCommitActivity(owner, repo, timeout);
+    cache.set(CACHE_KEY_ACTIVITY, activity);
+    renderContributionGraph(activity);
+  } catch (err) {
+    // API falhou — verificar se há cache stale disponível
+    const cached = cache.get(CACHE_KEY_ACTIVITY);
+    if (cached !== null) {
+      renderContributionGraph(cached);
+    }
+    // Se não há cache, o gráfico permanece vazio (sem renderização de erro específica)
+  }
+}
+
+/**
+ * Busca avatares de todos os membros da equipe e re-renderiza a seção de equipe.
+ * Se qualquer avatar falhar, o membro usa o avatar padrão (fallback no renderTeam).
+ *
+ * @param {import('./configLoader.js').TeamMember[]} members
+ * @param {number} timeout
+ */
+async function loadAndRenderTeamAvatars(members, timeout) {
+  const avatarEntries = await Promise.allSettled(
+    members.map(async (member) => {
+      const url = await fetchAvatarUrl(member.github, timeout);
+      return [member.github, url];
+    }),
+  );
+
+  /** @type {Map<string, string>} */
+  const avatars = new Map();
+  for (const result of avatarEntries) {
+    if (result.status === 'fulfilled') {
+      const [username, url] = result.value;
+      avatars.set(username, url);
+    }
+    // Membros com falha ficam fora do mapa → renderTeam usa avatar padrão
+  }
+
+  renderTeam(members, avatars);
+}
+
+/**
+ * Ponto de entrada principal da Showcase_Page.
+ * Orquestra o carregamento de configuração, renderização estática e chamadas à API.
+ */
+async function init() {
+  // ── 1. Carregar configuração ──────────────────────────────────────────────
+  const config = await loadConfig();
+
+  const owner   = config.repo?.owner   ?? 'tokemize-org';
+  const repo    = config.repo?.name    ?? 'tokemize';
+  const timeout = config.repo?.apiTimeout ?? 8000;
+
+  // ── 2. Renderizar seções estáticas IMEDIATAMENTE ──────────────────────────
+  // Não aguarda a API — o usuário vê o conteúdo estático instantaneamente.
+  renderHero(config);
+  renderTechStack(config);
+  renderProgressTracker(config.modules);
+
+  // Renderização inicial da equipe sem avatares (fallback para avatar padrão)
+  renderTeam(config.team, new Map());
+
+  // ── 3. Carregar dados dinâmicos da API (ou cache) em paralelo ─────────────
+  await Promise.allSettled([
+    loadAndRenderStats(owner, repo, timeout),
+    loadAndRenderContributionGraph(owner, repo, timeout),
+  ]);
+
+  // ── 4. Buscar avatares e re-renderizar equipe ─────────────────────────────
+  // Feito após os dados principais para não bloquear o carregamento das stats.
+  await loadAndRenderTeamAvatars(config.team, timeout);
+}
+
+document.addEventListener('DOMContentLoaded', init);

--- a/docs/showcase/assets/default-avatar.svg
+++ b/docs/showcase/assets/default-avatar.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 80 80" width="80" height="80" role="img" aria-label="Avatar padrão">
+  <title>Avatar padrão</title>
+  <circle cx="40" cy="40" r="40" fill="#1c2128"/>
+  <circle cx="40" cy="32" r="14" fill="#30363d"/>
+  <ellipse cx="40" cy="68" rx="22" ry="16" fill="#30363d"/>
+</svg>

--- a/docs/showcase/cacheStore.js
+++ b/docs/showcase/cacheStore.js
@@ -1,0 +1,75 @@
+/**
+ * CacheStore — camada de cache sobre localStorage.
+ *
+ * Cada entrada é armazenada como:
+ *   { "data": <T>, "timestamp": <number ms> }
+ *
+ * Todas as chaves são prefixadas com `tokemize_cache_` para evitar colisões.
+ */
+
+/** TTL padrão: 1 hora em milissegundos. */
+export const DEFAULT_TTL = 3600000;
+
+const KEY_PREFIX = 'tokemize_cache_';
+
+export class CacheStore {
+  /**
+   * Recupera o dado armazenado para a chave informada.
+   * Retorna `null` se a entrada não existir ou se o localStorage estiver indisponível.
+   *
+   * @template T
+   * @param {string} key
+   * @returns {T | null}
+   */
+  get(key) {
+    try {
+      const raw = localStorage.getItem(KEY_PREFIX + key);
+      if (raw === null) return null;
+      const entry = JSON.parse(raw);
+      return entry.data ?? null;
+    } catch {
+      return null;
+    }
+  }
+
+  /**
+   * Armazena `data` associado à `key` com o timestamp atual.
+   * Não faz nada se o localStorage estiver indisponível.
+   *
+   * @template T
+   * @param {string} key
+   * @param {T} data
+   * @returns {void}
+   */
+  set(key, data) {
+    try {
+      const entry = { data, timestamp: Date.now() };
+      localStorage.setItem(KEY_PREFIX + key, JSON.stringify(entry));
+    } catch {
+      // localStorage indisponível (modo privado / SSR) — falha silenciosa
+    }
+  }
+
+  /**
+   * Verifica se a entrada para `key` está desatualizada em relação a `maxAgeMs`.
+   *
+   * Retorna `true` se:
+   *   - a entrada não existir no cache, ou
+   *   - `(Date.now() - entry.timestamp) > maxAgeMs`
+   *
+   * @param {string} key
+   * @param {number} maxAgeMs
+   * @returns {boolean}
+   */
+  isStale(key, maxAgeMs) {
+    try {
+      const raw = localStorage.getItem(KEY_PREFIX + key);
+      if (raw === null) return true;
+      const entry = JSON.parse(raw);
+      if (typeof entry.timestamp !== 'number') return true;
+      return (Date.now() - entry.timestamp) > maxAgeMs;
+    } catch {
+      return true;
+    }
+  }
+}

--- a/docs/showcase/components/contributionGraph.js
+++ b/docs/showcase/components/contributionGraph.js
@@ -1,0 +1,176 @@
+/**
+ * contributionGraph.js — Componente de gráfico de barras SVG de contribuições
+ *
+ * Renderiza atividade semanal de commits como gráfico de barras SVG acessível.
+ * Requirements: 3.1, 3.2, 3.3, 3.4
+ */
+
+/** Paleta de cores distintas para autores (pelo menos 10 cores) */
+const AUTHOR_COLOR_PALETTE = [
+  '#58a6ff', // accent blue
+  '#3fb950', // green
+  '#d29922', // yellow/amber
+  '#f85149', // red
+  '#bc8cff', // purple
+  '#ff7b72', // coral
+  '#79c0ff', // light blue
+  '#56d364', // light green
+  '#e3b341', // gold
+  '#ff9bce', // pink
+  '#ffa657', // orange
+  '#8b949e', // neutral gray
+];
+
+/**
+ * Retorna um Map com uma cor distinta por autor.
+ *
+ * @param {string[]} authors - Array de usernames
+ * @returns {Map<string, string>} Mapa de username → cor hex
+ */
+export function getAuthorColors(authors) {
+  const colorMap = new Map();
+  const uniqueAuthors = [...new Set(authors)];
+
+  uniqueAuthors.forEach((author, index) => {
+    colorMap.set(author, AUTHOR_COLOR_PALETTE[index % AUTHOR_COLOR_PALETTE.length]);
+  });
+
+  return colorMap;
+}
+
+/**
+ * Formata uma data ISO (ex: "2025-01-06") para label abreviado (ex: "Jan 06").
+ *
+ * @param {string} isoDate - Data no formato "YYYY-MM-DD"
+ * @returns {string} Label formatado
+ */
+function formatWeekLabel(isoDate) {
+  try {
+    const date = new Date(isoDate + 'T00:00:00');
+    return date.toLocaleDateString('pt-BR', { month: 'short', day: '2-digit' });
+  } catch {
+    return isoDate;
+  }
+}
+
+/**
+ * Renderiza um gráfico de barras SVG de atividade semanal de commits.
+ *
+ * @typedef {Object} WeeklyActivity
+ * @property {string} week - Data ISO do início da semana (ex: "2025-01-06")
+ * @property {number} totalCommits - Total de commits na semana
+ * @property {Object} byAuthor - Mapa de username → número de commits
+ *
+ * @param {WeeklyActivity[]} activity - Array de atividade semanal
+ */
+export function renderContributionGraph(activity) {
+  const container = document.getElementById('contribution-graph-container');
+  if (!container) return;
+
+  // Limpa o conteúdo anterior
+  container.innerHTML = '';
+
+  const totalCommits = activity.reduce((sum, w) => sum + (w.totalCommits ?? 0), 0);
+  const ariaLabel = `Gráfico de contribuições: ${totalCommits} commits nas últimas ${activity.length} semanas`;
+
+  // Dimensões do SVG
+  const svgWidth = 780;
+  const svgHeight = 200;
+  const barWidth = 40;
+  const barGap = 20;
+  const paddingTop = 10;
+  const paddingBottom = 40; // espaço para labels do eixo X
+  const paddingLeft = 10;
+  const chartHeight = svgHeight - paddingTop - paddingBottom;
+
+  // Altura máxima de commits para escala
+  const maxCommits = Math.max(...activity.map(w => w.totalCommits ?? 0), 1);
+
+  // Cria o SVG
+  const svgNS = 'http://www.w3.org/2000/svg';
+  const svg = document.createElementNS(svgNS, 'svg');
+  svg.setAttribute('viewBox', `0 0 ${svgWidth} ${svgHeight}`);
+  svg.setAttribute('width', '100%');
+  svg.setAttribute('role', 'img');
+  svg.setAttribute('aria-label', ariaLabel);
+
+  // <title> interno para acessibilidade
+  const titleEl = document.createElementNS(svgNS, 'title');
+  titleEl.textContent = ariaLabel;
+  svg.appendChild(titleEl);
+
+  // Referência ao tooltip
+  const tooltip = document.getElementById('graph-tooltip');
+
+  // Renderiza cada barra
+  activity.forEach((week, index) => {
+    const commits = week.totalCommits ?? 0;
+    const barHeight = chartHeight * (commits / maxCommits);
+    const x = paddingLeft + index * (barWidth + barGap);
+    const y = paddingTop + (chartHeight - barHeight);
+
+    // Grupo da barra (barra + label)
+    const group = document.createElementNS(svgNS, 'g');
+    group.setAttribute('class', 'bar-group');
+
+    // Retângulo da barra
+    const rect = document.createElementNS(svgNS, 'rect');
+    rect.setAttribute('x', String(x));
+    rect.setAttribute('y', String(y));
+    rect.setAttribute('width', String(barWidth));
+    rect.setAttribute('height', String(Math.max(barHeight, 1)));
+    rect.setAttribute('fill', 'var(--color-accent, #58a6ff)');
+    rect.setAttribute('rx', '3');
+    rect.setAttribute('ry', '3');
+    rect.setAttribute('tabindex', '0');
+    rect.setAttribute('aria-label', `${commits} commits — semana de ${week.week}`);
+
+    // Tooltip via mouse events
+    if (tooltip) {
+      rect.addEventListener('mouseenter', (e) => {
+        tooltip.textContent = `${commits} commits — semana de ${week.week}`;
+        tooltip.classList.add('visible');
+        tooltip.removeAttribute('aria-hidden');
+      });
+
+      rect.addEventListener('mousemove', (e) => {
+        tooltip.style.left = `${e.clientX + 12}px`;
+        tooltip.style.top = `${e.clientY - 28}px`;
+      });
+
+      rect.addEventListener('mouseleave', () => {
+        tooltip.classList.remove('visible');
+        tooltip.setAttribute('aria-hidden', 'true');
+      });
+
+      // Suporte a teclado (focus/blur)
+      rect.addEventListener('focus', (e) => {
+        tooltip.textContent = `${commits} commits — semana de ${week.week}`;
+        tooltip.classList.add('visible');
+        tooltip.removeAttribute('aria-hidden');
+      });
+
+      rect.addEventListener('blur', () => {
+        tooltip.classList.remove('visible');
+        tooltip.setAttribute('aria-hidden', 'true');
+      });
+    }
+
+    group.appendChild(rect);
+
+    // Label do eixo X
+    const label = document.createElementNS(svgNS, 'text');
+    label.setAttribute('x', String(x + barWidth / 2));
+    label.setAttribute('y', String(svgHeight - 8));
+    label.setAttribute('text-anchor', 'middle');
+    label.setAttribute('font-size', '10');
+    label.setAttribute('fill', 'var(--color-text-secondary, #8b949e)');
+    label.setAttribute('aria-hidden', 'true');
+    label.textContent = formatWeekLabel(week.week);
+
+    group.appendChild(label);
+    svg.appendChild(group);
+  });
+
+  container.appendChild(svg);
+}

--- a/docs/showcase/components/hero.js
+++ b/docs/showcase/components/hero.js
@@ -1,0 +1,64 @@
+/**
+ * hero.js — Componente de renderização da seção Hero
+ *
+ * Popula os elementos da seção #hero e #pipeline com dados do config.json.
+ * Requirements: 5.1, 5.2, 5.3
+ */
+
+/**
+ * Renderiza a seção hero com os dados de configuração.
+ *
+ * @param {import('../configLoader.js').AppConfig} config
+ */
+export function renderHero(config) {
+  // Atualiza o título principal
+  const heroTitle = document.getElementById('hero-title');
+  if (heroTitle) {
+    heroTitle.textContent = config.projectName;
+  }
+
+  // Atualiza o tagline
+  const heroTagline = document.querySelector('.hero-tagline');
+  if (heroTagline) {
+    heroTagline.textContent = config.tagline;
+  }
+
+  // Popula a lista de problemas
+  const problemsList = document.getElementById('problems-list');
+  if (problemsList && Array.isArray(config.problems)) {
+    problemsList.innerHTML = '';
+    for (const problem of config.problems) {
+      const li = document.createElement('li');
+      li.textContent = problem;
+      problemsList.appendChild(li);
+    }
+  }
+
+  // Popula o pipeline como sequência visual com setas
+  const pipelineContainer = document.getElementById('pipeline-container');
+  if (pipelineContainer && Array.isArray(config.pipeline)) {
+    pipelineContainer.innerHTML = '';
+    const steps = config.pipeline;
+    const middleIndex = Math.floor(steps.length / 2);
+
+    steps.forEach((step, index) => {
+      // Cria o elemento do passo
+      const div = document.createElement('div');
+      div.className = 'pipeline-step';
+      if (index === middleIndex) {
+        div.className += ' pipeline-step--highlight';
+      }
+      div.textContent = step;
+      pipelineContainer.appendChild(div);
+
+      // Adiciona seta entre os passos (não após o último)
+      if (index < steps.length - 1) {
+        const arrow = document.createElement('span');
+        arrow.className = 'pipeline-arrow';
+        arrow.setAttribute('aria-hidden', 'true');
+        arrow.textContent = '→';
+        pipelineContainer.appendChild(arrow);
+      }
+    });
+  }
+}

--- a/docs/showcase/components/progressTracker.js
+++ b/docs/showcase/components/progressTracker.js
@@ -1,0 +1,107 @@
+/**
+ * progressTracker.js — Componente de rastreamento de progresso por módulo
+ *
+ * Calcula e renderiza o progresso geral e o status de cada módulo.
+ * Requirements: 4.1, 4.2, 4.3, 4.4
+ */
+
+/**
+ * Mapa de status para labels em português.
+ */
+const STATUS_LABELS = {
+  done: 'Concluído',
+  in_progress: 'Em desenvolvimento',
+  planned: 'Planejado',
+};
+
+/**
+ * Calcula o percentual de módulos concluídos.
+ *
+ * @typedef {Object} ModuleConfig
+ * @property {string} id - Identificador do módulo
+ * @property {string} label - Nome de exibição
+ * @property {"done"|"in_progress"|"planned"} status - Status do módulo
+ *
+ * @param {ModuleConfig[]} modules - Array de módulos
+ * @returns {number} Percentual de módulos com status "done" (0–100)
+ */
+export function calculateProgress(modules) {
+  if (!modules || modules.length === 0) return 0;
+  const doneCount = modules.filter(m => m.status === 'done').length;
+  return (doneCount / modules.length) * 100;
+}
+
+/**
+ * Renderiza o rastreador de progresso no elemento #progress-container.
+ *
+ * Exibe:
+ * 1. Barra de progresso geral com percentual
+ * 2. Grid de cards por módulo com label e badge de status
+ *
+ * O status exibido SEMPRE vem do campo `status` do módulo (prioridade absoluta).
+ *
+ * @param {ModuleConfig[]} modules - Array de módulos
+ */
+export function renderProgressTracker(modules) {
+  const container = document.getElementById('progress-container');
+  if (!container) return;
+
+  container.innerHTML = '';
+
+  const percentual = Math.round(calculateProgress(modules));
+
+  // ── Barra de progresso geral ──────────────────────────────────
+  const progressOverall = document.createElement('div');
+  progressOverall.className = 'progress-overall';
+
+  const progressLabel = document.createElement('div');
+  progressLabel.className = 'progress-overall-label';
+
+  const labelText = document.createElement('span');
+  labelText.textContent = 'Progresso Geral';
+
+  const percentText = document.createElement('span');
+  percentText.textContent = `${percentual}%`;
+
+  progressLabel.appendChild(labelText);
+  progressLabel.appendChild(percentText);
+
+  const progressTrack = document.createElement('div');
+  progressTrack.className = 'progress-bar-track';
+
+  const progressFill = document.createElement('div');
+  progressFill.className = 'progress-bar-fill';
+  progressFill.style.width = `${percentual}%`;
+
+  progressTrack.appendChild(progressFill);
+  progressOverall.appendChild(progressLabel);
+  progressOverall.appendChild(progressTrack);
+  container.appendChild(progressOverall);
+
+  // ── Grid de módulos ───────────────────────────────────────────
+  const modulesGrid = document.createElement('div');
+  modulesGrid.className = 'modules-grid';
+
+  for (const mod of modules) {
+    // O status exibido SEMPRE vem do campo status do módulo (prioridade absoluta)
+    const status = mod.status;
+    const statusLabel = STATUS_LABELS[status] ?? status;
+
+    const card = document.createElement('div');
+    card.className = 'module-card';
+
+    const labelEl = document.createElement('span');
+    labelEl.className = 'module-label';
+    labelEl.textContent = mod.label;
+
+    const badge = document.createElement('span');
+    badge.className = `module-badge module-badge--${status}`;
+    badge.textContent = statusLabel;
+
+    card.appendChild(labelEl);
+    card.appendChild(badge);
+    modulesGrid.appendChild(card);
+  }
+
+  container.appendChild(modulesGrid);
+}

--- a/docs/showcase/components/stats.js
+++ b/docs/showcase/components/stats.js
@@ -1,0 +1,100 @@
+/**
+ * stats.js — Componente de renderização da seção de Estatísticas
+ *
+ * Popula o elemento #stats-grid com os dados de RepoStats.
+ * Requirements: 2.1, 2.2, 2.3, 2.4, 2.5, 2.6
+ */
+
+/**
+ * Formata uma data ISO 8601 para exibição localizada em pt-BR.
+ *
+ * @param {string} isoDate - Data no formato ISO 8601
+ * @returns {string} Data formatada
+ */
+function formatDate(isoDate) {
+  try {
+    const date = new Date(isoDate);
+    return date.toLocaleDateString('pt-BR', {
+      day: '2-digit',
+      month: '2-digit',
+      year: 'numeric',
+    });
+  } catch {
+    return isoDate;
+  }
+}
+
+/**
+ * Cria um card de estatística.
+ *
+ * @param {string} label - Rótulo do card
+ * @param {string|number} value - Valor a exibir
+ * @returns {HTMLElement}
+ */
+function createStatCard(label, value) {
+  const card = document.createElement('div');
+  card.className = 'stat-card';
+
+  const labelEl = document.createElement('span');
+  labelEl.className = 'stat-label';
+  labelEl.textContent = label;
+
+  const valueEl = document.createElement('span');
+  valueEl.className = 'stat-value';
+  valueEl.textContent = String(value);
+
+  card.appendChild(labelEl);
+  card.appendChild(valueEl);
+
+  return card;
+}
+
+/**
+ * Renderiza as estatísticas do repositório no elemento #stats-grid.
+ *
+ * Quando `stats` é null, exibe um estado de erro amigável.
+ * Quando `stale` é true, exibe um banner de aviso de dados desatualizados.
+ *
+ * @param {import('../apiClient.js').RepoStats|null} stats
+ * @param {boolean} stale
+ */
+export function renderStats(stats, stale) {
+  const grid = document.getElementById('stats-grid');
+  if (!grid) {
+    return;
+  }
+
+  grid.innerHTML = '';
+
+  // Estado de erro: stats indisponível
+  if (stats === null) {
+    const errorEl = document.createElement('div');
+    errorEl.className = 'stats-error';
+    errorEl.textContent = 'Não foi possível carregar as estatísticas.';
+    grid.appendChild(errorEl);
+    return;
+  }
+
+  // Banner de dados desatualizados (antes dos cards)
+  if (stale) {
+    const banner = document.createElement('div');
+    banner.className = 'stats-stale-banner';
+    banner.setAttribute('data-stale', 'true');
+    banner.textContent = '⚠ Dados podem estar desatualizados';
+    grid.appendChild(banner);
+  }
+
+  // Seis cards de estatísticas
+  const cards = [
+    { label: 'Total de Commits',  value: stats.totalCommits },
+    { label: 'PRs Abertos',       value: stats.openPRs },
+    { label: 'PRs Fechados',      value: stats.closedPRs },
+    { label: 'Contribuidores',    value: stats.contributors },
+    { label: 'Branches Ativas',   value: stats.activeBranches },
+    { label: 'Último Commit',     value: formatDate(stats.lastCommitAt) },
+  ];
+
+  for (const { label, value } of cards) {
+    grid.appendChild(createStatCard(label, value));
+  }
+}

--- a/docs/showcase/components/team.js
+++ b/docs/showcase/components/team.js
@@ -1,0 +1,63 @@
+/**
+ * team.js — Componente de renderização da seção de Equipe
+ *
+ * Renderiza os membros da equipe com avatar, nome e link para o GitHub.
+ * Requirements: 6.1, 6.2, 6.3
+ */
+
+/** Caminho para o avatar padrão quando o username não está no mapa de avatares. */
+const DEFAULT_AVATAR = './assets/default-avatar.svg';
+
+/**
+ * Renderiza a lista de membros da equipe no elemento #team-list.
+ *
+ * Para cada membro:
+ * - Usa a URL do avatar fornecida no mapa `avatars` se disponível
+ * - Usa `DEFAULT_AVATAR` como fallback quando o username não está no mapa
+ *
+ * @typedef {Object} TeamMember
+ * @property {string} name   - Nome completo do membro
+ * @property {string} github - Username do GitHub
+ *
+ * @param {TeamMember[]} members - Array de membros da equipe
+ * @param {Map<string, string>} avatars - Mapa de username → URL do avatar
+ */
+export function renderTeam(members, avatars) {
+  const list = document.getElementById('team-list');
+  if (!list) return;
+
+  list.innerHTML = '';
+
+  for (const member of members) {
+    const avatarUrl = avatars.has(member.github)
+      ? avatars.get(member.github)
+      : DEFAULT_AVATAR;
+
+    const li = document.createElement('li');
+    li.className = 'team-member';
+
+    // Avatar
+    const img = document.createElement('img');
+    img.className = 'team-avatar';
+    img.src = avatarUrl;
+    img.alt = `Avatar de ${member.name}`;
+
+    // Nome
+    const nameSpan = document.createElement('span');
+    nameSpan.className = 'team-name';
+    nameSpan.textContent = member.name;
+
+    // Link GitHub
+    const githubLink = document.createElement('a');
+    githubLink.className = 'team-github-link';
+    githubLink.href = `https://github.com/${member.github}`;
+    githubLink.target = '_blank';
+    githubLink.rel = 'noopener noreferrer';
+    githubLink.textContent = `@${member.github}`;
+
+    li.appendChild(img);
+    li.appendChild(nameSpan);
+    li.appendChild(githubLink);
+    list.appendChild(li);
+  }
+}

--- a/docs/showcase/components/techStack.js
+++ b/docs/showcase/components/techStack.js
@@ -1,0 +1,40 @@
+/**
+ * techStack.js — Componente de renderização da seção Tech Stack
+ *
+ * Popula o elemento #tech-stack-list com os itens de config.techStack.
+ * Requirements: 5.4
+ */
+
+/**
+ * @typedef {Object} TechItem
+ * @property {string} name - Nome da tecnologia
+ * @property {string} url  - URL da documentação
+ */
+
+/**
+ * Renderiza a lista de tecnologias com links externos.
+ *
+ * @param {import('../configLoader.js').AppConfig} config
+ */
+export function renderTechStack(config) {
+  const techList = document.getElementById('tech-stack-list');
+  if (!techList || !Array.isArray(config.techStack)) {
+    return;
+  }
+
+  techList.innerHTML = '';
+
+  for (const tech of config.techStack) {
+    const li = document.createElement('li');
+    li.className = 'tech-item';
+
+    const a = document.createElement('a');
+    a.href = tech.url;
+    a.target = '_blank';
+    a.rel = 'noopener noreferrer';
+    a.textContent = tech.name;
+
+    li.appendChild(a);
+    techList.appendChild(li);
+  }
+}

--- a/docs/showcase/config.json
+++ b/docs/showcase/config.json
@@ -1,0 +1,41 @@
+{
+  "projectName": "Tokemize",
+  "tagline": "Uma camada intermediária que melhora como usamos IA",
+  "repo": {
+    "owner": "tokemize-org",
+    "name": "tokemize",
+    "apiTimeout": 8000
+  },
+  "problems": [
+    "Alto custo de tokens",
+    "Respostas imprecisas e alucinações",
+    "Processamento ineficiente"
+  ],
+  "pipeline": ["Entrada Bruta", "Tokemize", "Entrada Otimizada"],
+  "techStack": [
+    { "name": "Python", "url": "https://docs.python.org/3/" },
+    { "name": "Tree-sitter", "url": "https://tree-sitter.github.io/tree-sitter/" },
+    { "name": "FAISS", "url": "https://faiss.ai/index.html" },
+    { "name": "OpenAI API", "url": "https://platform.openai.com/docs" },
+    { "name": "Anthropic API", "url": "https://docs.anthropic.com" }
+  ],
+  "modules": [
+    { "id": "parser",                  "label": "Parser",          "status": "in_progress" },
+    { "id": "indexer",                 "label": "Indexer",         "status": "in_progress" },
+    { "id": "selector",                "label": "Selector",        "status": "planned"     },
+    { "id": "optimizer",               "label": "Optimizer",       "status": "planned"     },
+    { "id": "integrations/llm",        "label": "LLM Integration", "status": "in_progress" },
+    { "id": "integrations/embeddings", "label": "Embeddings",      "status": "planned"     }
+  ],
+  "team": [
+    { "name": "Eneri da Costa Junior",     "github": "jrcosta"          },
+    { "name": "Guilherme Valerio Mertens", "github": "gvmertens"        },
+    { "name": "Paulo Sergio",              "github": "PauloSergioLR"    },
+    { "name": "Samuel Magalhães Marques", "github": "samuelmarquesgit" },
+    { "name": "Eduardo Notari",            "github": "edunotari"        }
+  ],
+  "links": {
+    "repo": "https://github.com/tokemize-org/tokemize",
+    "readme": "https://github.com/tokemize-org/tokemize#readme"
+  }
+}

--- a/docs/showcase/configLoader.js
+++ b/docs/showcase/configLoader.js
@@ -1,0 +1,136 @@
+/**
+ * @typedef {Object} ModuleConfig
+ * @property {string} id        - Identificador do módulo (ex: "parser")
+ * @property {string} label     - Nome de exibição
+ * @property {"done"|"in_progress"|"planned"} status - Status manual
+ */
+
+/**
+ * @typedef {Object} TeamMember
+ * @property {string} name       - Nome completo
+ * @property {string} github     - Username do GitHub
+ * @property {string} [avatar]   - URL de avatar (opcional; fallback para API)
+ */
+
+/**
+ * @typedef {Object} AppConfig
+ * @property {string}         projectName
+ * @property {string}         tagline
+ * @property {ModuleConfig[]} modules
+ * @property {TeamMember[]}   team
+ * @property {Object}         links       - Links externos (docs, repo, etc.)
+ */
+
+/** Campos obrigatórios que devem estar presentes no config.json */
+const REQUIRED_FIELDS = ['projectName', 'tagline', 'modules', 'team', 'links'];
+
+/**
+ * Configuração padrão do Tokemize.
+ * Usada como fallback quando config.json está ausente, malformado ou incompleto.
+ *
+ * @type {AppConfig}
+ */
+export const DEFAULT_CONFIG = {
+  projectName: 'Tokemize',
+  tagline: 'Uma camada intermediária que melhora como usamos IA',
+  repo: {
+    owner: 'tokemize-org',
+    name: 'tokemize',
+    apiTimeout: 8000,
+  },
+  problems: [
+    'Alto custo de tokens',
+    'Respostas imprecisas e alucinações',
+    'Processamento ineficiente',
+  ],
+  pipeline: ['Entrada Bruta', 'Tokemize', 'Entrada Otimizada'],
+  techStack: [
+    { name: 'Python', url: 'https://docs.python.org/3/' },
+    { name: 'Tree-sitter', url: 'https://tree-sitter.github.io/tree-sitter/' },
+    { name: 'FAISS', url: 'https://faiss.ai/index.html' },
+    { name: 'OpenAI API', url: 'https://platform.openai.com/docs' },
+    { name: 'Anthropic API', url: 'https://docs.anthropic.com' },
+  ],
+  modules: [
+    { id: 'parser',                   label: 'Parser',          status: 'in_progress' },
+    { id: 'indexer',                  label: 'Indexer',         status: 'in_progress' },
+    { id: 'selector',                 label: 'Selector',        status: 'planned'     },
+    { id: 'optimizer',                label: 'Optimizer',       status: 'planned'     },
+    { id: 'integrations/llm',         label: 'LLM Integration', status: 'in_progress' },
+    { id: 'integrations/embeddings',  label: 'Embeddings',      status: 'planned'     },
+  ],
+  team: [
+    { name: 'Eneri da Costa Junior',      github: 'jrcosta'          },
+    { name: 'Guilherme Valerio Mertens',  github: 'gvmertens'        },
+    { name: 'Paulo Sergio',               github: 'PauloSergioLR'    },
+    { name: 'Samuel Magalhães Marques',   github: 'samuelmarquesgit' },
+    { name: 'Eduardo Notari',             github: 'edunotari'        },
+  ],
+  links: {
+    repo: 'https://github.com/tokemize-org/tokemize',
+    readme: 'https://github.com/tokemize-org/tokemize#readme',
+  },
+};
+
+/**
+ * Valida se o objeto de configuração possui todos os campos obrigatórios.
+ *
+ * @param {unknown} config - Objeto a ser validado
+ * @returns {boolean} `true` se todos os campos obrigatórios estiverem presentes
+ */
+function hasRequiredFields(config) {
+  if (config === null || typeof config !== 'object') return false;
+  return REQUIRED_FIELDS.every((field) => field in config);
+}
+
+/**
+ * Carrega e valida o arquivo `config.json`.
+ *
+ * Comportamento de fallback (retorna `DEFAULT_CONFIG` + emite `console.warn`):
+ * - Arquivo ausente (response.ok === false / 404)
+ * - JSON malformado (SyntaxError no parse)
+ * - Campos obrigatórios faltando
+ *
+ * @returns {Promise<AppConfig>} Configuração carregada ou `DEFAULT_CONFIG`
+ */
+export async function loadConfig() {
+  let response;
+
+  try {
+    response = await fetch('config.json');
+  } catch (networkError) {
+    console.warn(
+      '[ConfigLoader] Falha ao buscar config.json (erro de rede). Usando DEFAULT_CONFIG.',
+      networkError,
+    );
+    return DEFAULT_CONFIG;
+  }
+
+  if (!response.ok) {
+    console.warn(
+      `[ConfigLoader] config.json não encontrado (HTTP ${response.status}). Usando DEFAULT_CONFIG.`,
+    );
+    return DEFAULT_CONFIG;
+  }
+
+  let parsed;
+  try {
+    parsed = await response.json();
+  } catch (syntaxError) {
+    console.warn(
+      '[ConfigLoader] config.json contém JSON malformado. Usando DEFAULT_CONFIG.',
+      syntaxError,
+    );
+    return DEFAULT_CONFIG;
+  }
+
+  if (!hasRequiredFields(parsed)) {
+    const missing = REQUIRED_FIELDS.filter((f) => !(f in (parsed ?? {})));
+    console.warn(
+      `[ConfigLoader] config.json está faltando campos obrigatórios: ${missing.join(', ')}. Usando DEFAULT_CONFIG.`,
+    );
+    return DEFAULT_CONFIG;
+  }
+
+  return parsed;
+}

--- a/docs/showcase/index.html
+++ b/docs/showcase/index.html
@@ -1,0 +1,119 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <meta name="description" content="Tokemize — Uma camada intermediária que melhora como usamos IA" />
+    <title>Tokemize — Showcase</title>
+    <link rel="stylesheet" href="style.css" />
+  </head>
+  <body>
+    <a class="skip-link" href="#hero">Pular para o conteúdo principal</a>
+
+    <header class="site-header" role="banner">
+      <nav class="site-nav" aria-label="Navegação principal">
+        <a href="#hero" class="nav-logo">Tokemize</a>
+        <ul class="nav-links" role="list">
+          <li><a href="#stats">Estatísticas</a></li>
+          <li><a href="#contribution-graph">Contribuições</a></li>
+          <li><a href="#progress">Progresso</a></li>
+          <li><a href="#pipeline">Pipeline</a></li>
+          <li><a href="#tech-stack">Tecnologias</a></li>
+          <li><a href="#team">Equipe</a></li>
+        </ul>
+      </nav>
+    </header>
+
+    <main id="main-content">
+
+      <!-- ===== HERO ===== -->
+      <section id="hero" aria-labelledby="hero-title">
+        <div class="section-inner">
+          <h1 id="hero-title" class="hero-title">Tokemize</h1>
+          <p class="hero-tagline">Uma camada intermediária que melhora como usamos IA</p>
+
+          <div class="hero-problems" aria-label="Problemas que o Tokemize resolve">
+            <h2 class="problems-heading">Problemas que resolvemos</h2>
+            <ul class="problems-list" role="list" id="problems-list">
+              <!-- Preenchido por renderHero() -->
+            </ul>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== STATS ===== -->
+      <section id="stats" aria-labelledby="stats-title">
+        <div class="section-inner">
+          <h2 id="stats-title" class="section-title">Estatísticas do Repositório</h2>
+          <div class="stats-grid" id="stats-grid" aria-live="polite" aria-atomic="true">
+            <!-- Preenchido por renderStats() -->
+            <p class="loading-placeholder" aria-label="Carregando estatísticas">Carregando…</p>
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== CONTRIBUTION GRAPH ===== -->
+      <section id="contribution-graph" aria-labelledby="graph-title">
+        <div class="section-inner">
+          <h2 id="graph-title" class="section-title">Atividade de Contribuições</h2>
+          <div id="contribution-graph-container" class="graph-container">
+            <!-- Preenchido por renderContributionGraph() -->
+            <p class="loading-placeholder" aria-label="Carregando gráfico de contribuições">Carregando…</p>
+          </div>
+          <div id="graph-tooltip" role="tooltip" aria-hidden="true" class="graph-tooltip"></div>
+        </div>
+      </section>
+
+      <!-- ===== PROGRESS ===== -->
+      <section id="progress" aria-labelledby="progress-title">
+        <div class="section-inner">
+          <h2 id="progress-title" class="section-title">Progresso por Módulo</h2>
+          <div id="progress-container">
+            <!-- Preenchido por renderProgressTracker() -->
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== PIPELINE ===== -->
+      <section id="pipeline" aria-labelledby="pipeline-title">
+        <div class="section-inner">
+          <h2 id="pipeline-title" class="section-title">Pipeline</h2>
+          <div id="pipeline-container" class="pipeline-flow" aria-label="Fluxo do pipeline Tokemize">
+            <!-- Preenchido por renderHero() / renderPipeline() -->
+          </div>
+        </div>
+      </section>
+
+      <!-- ===== TECH STACK ===== -->
+      <section id="tech-stack" aria-labelledby="tech-title">
+        <div class="section-inner">
+          <h2 id="tech-title" class="section-title">Tecnologias</h2>
+          <ul id="tech-stack-list" class="tech-list" role="list">
+            <!-- Preenchido por renderTechStack() -->
+          </ul>
+        </div>
+      </section>
+
+      <!-- ===== TEAM ===== -->
+      <section id="team" aria-labelledby="team-title">
+        <div class="section-inner">
+          <h2 id="team-title" class="section-title">Equipe</h2>
+          <ul id="team-list" class="team-list" role="list">
+            <!-- Preenchido por renderTeam() -->
+          </ul>
+        </div>
+      </section>
+
+    </main>
+
+    <footer class="site-footer" role="contentinfo">
+      <p>
+        <a href="https://github.com/tokemize-org/tokemize" target="_blank" rel="noopener noreferrer">
+          Ver repositório no GitHub
+        </a>
+      </p>
+    </footer>
+
+    <script type="module" src="app.js"></script>
+  </body>
+</html>

--- a/docs/showcase/package-lock.json
+++ b/docs/showcase/package-lock.json
@@ -1,0 +1,2856 @@
+{
+  "name": "tokemize-showcase",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "tokemize-showcase",
+      "version": "1.0.0",
+      "devDependencies": {
+        "@vitest/coverage-v8": "^2.1.8",
+        "fast-check": "^3.22.0",
+        "jsdom": "^25.0.1",
+        "vitest": "^2.1.8"
+      }
+    },
+    "node_modules/@ampproject/remapping": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.3.0.tgz",
+      "integrity": "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.27.1",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
+      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.28.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
+      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.3",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.3.tgz",
+      "integrity": "sha512-b3ctpQwp+PROvU/cttc4OYl4MzfJUWy6FZg+PMXfzmt/+39iHVF0sDfqay8TQM3JA2EUOyKcFZt75jWriQijsA==",
+      "dev": true,
+      "dependencies": {
+        "@babel/types": "^7.29.0"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.0",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
+      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "dev": true,
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.27.1",
+        "@babel/helper-validator-identifier": "^7.28.5"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@bcoe/v8-coverage": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz",
+      "integrity": "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==",
+      "dev": true
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.21.5.tgz",
+      "integrity": "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.21.5.tgz",
+      "integrity": "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.21.5.tgz",
+      "integrity": "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.21.5.tgz",
+      "integrity": "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.21.5.tgz",
+      "integrity": "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.21.5.tgz",
+      "integrity": "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.21.5.tgz",
+      "integrity": "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.21.5.tgz",
+      "integrity": "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.21.5.tgz",
+      "integrity": "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.21.5.tgz",
+      "integrity": "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.21.5.tgz",
+      "integrity": "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.21.5.tgz",
+      "integrity": "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.21.5.tgz",
+      "integrity": "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.21.5.tgz",
+      "integrity": "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.21.5.tgz",
+      "integrity": "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.21.5.tgz",
+      "integrity": "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.21.5.tgz",
+      "integrity": "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.21.5.tgz",
+      "integrity": "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.21.5.tgz",
+      "integrity": "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.21.5.tgz",
+      "integrity": "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.21.5.tgz",
+      "integrity": "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@isaacs/cliui": {
+      "version": "8.0.2",
+      "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-8.0.2.tgz",
+      "integrity": "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==",
+      "dev": true,
+      "dependencies": {
+        "string-width": "^5.1.2",
+        "string-width-cjs": "npm:string-width@^4.2.0",
+        "strip-ansi": "^7.0.1",
+        "strip-ansi-cjs": "npm:strip-ansi@^6.0.1",
+        "wrap-ansi": "^8.1.0",
+        "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/@istanbuljs/schema": {
+      "version": "0.1.6",
+      "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.6.tgz",
+      "integrity": "sha512-+Sg6GCR/wy1oSmQDFq4LQDAhm3ETKnorxN+y5nbLULOR3P0c14f2Wurzj3/xqPXtasLFfHd5iRFQ7AJt4KH2cw==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "dev": true,
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "dev": true
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@pkgjs/parseargs": {
+      "version": "0.11.0",
+      "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
+      "integrity": "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==",
+      "dev": true,
+      "optional": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true
+    },
+    "node_modules/@vitest/coverage-v8": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/coverage-v8/-/coverage-v8-2.1.9.tgz",
+      "integrity": "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ==",
+      "dev": true,
+      "dependencies": {
+        "@ampproject/remapping": "^2.3.0",
+        "@bcoe/v8-coverage": "^0.2.3",
+        "debug": "^4.3.7",
+        "istanbul-lib-coverage": "^3.2.2",
+        "istanbul-lib-report": "^3.0.1",
+        "istanbul-lib-source-maps": "^5.0.6",
+        "istanbul-reports": "^3.1.7",
+        "magic-string": "^0.30.12",
+        "magicast": "^0.3.5",
+        "std-env": "^3.8.0",
+        "test-exclude": "^7.0.1",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@vitest/browser": "2.1.9",
+        "vitest": "2.1.9"
+      },
+      "peerDependenciesMeta": {
+        "@vitest/browser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/expect": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-2.1.9.tgz",
+      "integrity": "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-2.1.9.tgz",
+      "integrity": "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/spy": "2.1.9",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.12"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-2.1.9.tgz",
+      "integrity": "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-2.1.9.tgz",
+      "integrity": "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/utils": "2.1.9",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-2.1.9.tgz",
+      "integrity": "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-2.1.9.tgz",
+      "integrity": "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==",
+      "dev": true,
+      "dependencies": {
+        "tinyspy": "^3.0.2"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-2.1.9.tgz",
+      "integrity": "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/pretty-format": "2.1.9",
+        "loupe": "^3.1.2",
+        "tinyrainbow": "^1.2.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true
+    },
+    "node_modules/balanced-match": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.4.tgz",
+      "integrity": "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==",
+      "dev": true,
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
+      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      }
+    },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 16"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "dev": true,
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "dev": true,
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/eastasianwidth": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/eastasianwidth/-/eastasianwidth-0.2.0.tgz",
+      "integrity": "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==",
+      "dev": true
+    },
+    "node_modules/emoji-regex": {
+      "version": "9.2.2",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-9.2.2.tgz",
+      "integrity": "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg==",
+      "dev": true
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.21.5",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.21.5.tgz",
+      "integrity": "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.21.5",
+        "@esbuild/android-arm": "0.21.5",
+        "@esbuild/android-arm64": "0.21.5",
+        "@esbuild/android-x64": "0.21.5",
+        "@esbuild/darwin-arm64": "0.21.5",
+        "@esbuild/darwin-x64": "0.21.5",
+        "@esbuild/freebsd-arm64": "0.21.5",
+        "@esbuild/freebsd-x64": "0.21.5",
+        "@esbuild/linux-arm": "0.21.5",
+        "@esbuild/linux-arm64": "0.21.5",
+        "@esbuild/linux-ia32": "0.21.5",
+        "@esbuild/linux-loong64": "0.21.5",
+        "@esbuild/linux-mips64el": "0.21.5",
+        "@esbuild/linux-ppc64": "0.21.5",
+        "@esbuild/linux-riscv64": "0.21.5",
+        "@esbuild/linux-s390x": "0.21.5",
+        "@esbuild/linux-x64": "0.21.5",
+        "@esbuild/netbsd-x64": "0.21.5",
+        "@esbuild/openbsd-x64": "0.21.5",
+        "@esbuild/sunos-x64": "0.21.5",
+        "@esbuild/win32-arm64": "0.21.5",
+        "@esbuild/win32-ia32": "0.21.5",
+        "@esbuild/win32-x64": "0.21.5"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.3.0.tgz",
+      "integrity": "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==",
+      "dev": true,
+      "engines": {
+        "node": ">=12.0.0"
+      }
+    },
+    "node_modules/fast-check": {
+      "version": "3.23.2",
+      "resolved": "https://registry.npmjs.org/fast-check/-/fast-check-3.23.2.tgz",
+      "integrity": "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ],
+      "dependencies": {
+        "pure-rand": "^6.1.0"
+      },
+      "engines": {
+        "node": ">=8.0.0"
+      }
+    },
+    "node_modules/foreground-child": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/foreground-child/-/foreground-child-3.3.1.tgz",
+      "integrity": "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw==",
+      "dev": true,
+      "dependencies": {
+        "cross-spawn": "^7.0.6",
+        "signal-exit": "^4.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/glob": {
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-10.5.0.tgz",
+      "integrity": "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg==",
+      "deprecated": "Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me",
+      "dev": true,
+      "dependencies": {
+        "foreground-child": "^3.1.0",
+        "jackspeak": "^3.1.2",
+        "minimatch": "^9.0.4",
+        "minipass": "^7.1.2",
+        "package-json-from-dist": "^1.0.0",
+        "path-scurry": "^1.11.1"
+      },
+      "bin": {
+        "glob": "dist/esm/bin.mjs"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/glob/node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true
+    },
+    "node_modules/glob/node_modules/brace-expansion": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.0.tgz",
+      "integrity": "sha512-TN1kCZAgdgweJhWWpgKYrQaMNHcDULHkWwQIspdtjV4Y5aurRdZpjAqn6yX3FPqTA9ngHCc4hJxMAMgGfve85w==",
+      "dev": true,
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/glob/node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
+      "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
+      "dev": true,
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/html-escaper": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
+      "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
+      "dev": true
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true
+    },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "dev": true
+    },
+    "node_modules/istanbul-lib-coverage": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-3.2.2.tgz",
+      "integrity": "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/istanbul-lib-report": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-report/-/istanbul-lib-report-3.0.1.tgz",
+      "integrity": "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==",
+      "dev": true,
+      "dependencies": {
+        "istanbul-lib-coverage": "^3.0.0",
+        "make-dir": "^4.0.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-lib-source-maps": {
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/istanbul-lib-source-maps/-/istanbul-lib-source-maps-5.0.6.tgz",
+      "integrity": "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/trace-mapping": "^0.3.23",
+        "debug": "^4.1.1",
+        "istanbul-lib-coverage": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/istanbul-reports": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/istanbul-reports/-/istanbul-reports-3.2.0.tgz",
+      "integrity": "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==",
+      "dev": true,
+      "dependencies": {
+        "html-escaper": "^2.0.0",
+        "istanbul-lib-report": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/jackspeak": {
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/jackspeak/-/jackspeak-3.4.3.tgz",
+      "integrity": "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw==",
+      "dev": true,
+      "dependencies": {
+        "@isaacs/cliui": "^8.0.2"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      },
+      "optionalDependencies": {
+        "@pkgjs/parseargs": "^0.11.0"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true
+    },
+    "node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "dev": true,
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/magicast": {
+      "version": "0.3.5",
+      "resolved": "https://registry.npmjs.org/magicast/-/magicast-0.3.5.tgz",
+      "integrity": "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==",
+      "dev": true,
+      "dependencies": {
+        "@babel/parser": "^7.25.4",
+        "@babel/types": "^7.25.4",
+        "source-map-js": "^1.2.0"
+      }
+    },
+    "node_modules/make-dir": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-4.0.0.tgz",
+      "integrity": "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==",
+      "dev": true,
+      "dependencies": {
+        "semver": "^7.5.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "10.2.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.5.tgz",
+      "integrity": "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==",
+      "dev": true,
+      "dependencies": {
+        "brace-expansion": "^5.0.5"
+      },
+      "engines": {
+        "node": "18 || 20 || >=22"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/minipass": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/minipass/-/minipass-7.1.3.tgz",
+      "integrity": "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==",
+      "dev": true,
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      }
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.23",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.23.tgz",
+      "integrity": "sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==",
+      "dev": true
+    },
+    "node_modules/package-json-from-dist": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/package-json-from-dist/-/package-json-from-dist-1.0.1.tgz",
+      "integrity": "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw==",
+      "dev": true
+    },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/path-scurry": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/path-scurry/-/path-scurry-1.11.1.tgz",
+      "integrity": "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA==",
+      "dev": true,
+      "dependencies": {
+        "lru-cache": "^10.2.0",
+        "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-1.1.2.tgz",
+      "integrity": "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==",
+      "dev": true
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 14.16"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true
+    },
+    "node_modules/postcss": {
+      "version": "8.5.13",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.13.tgz",
+      "integrity": "sha512-qif0+jGGZoLWdHey3UFHHWP0H7Gbmsk8T5VEqyYFbWqPr1XqvLGBbk/sl8V5exGmcYJklJOhOQq1pV9IcsiFag==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/punycode": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.1.tgz",
+      "integrity": "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/pure-rand": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-6.1.0.tgz",
+      "integrity": "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/dubzzz"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/fast-check"
+        }
+      ]
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
+    "node_modules/semver": {
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
+      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "dev": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "dev": true,
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true
+    },
+    "node_modules/signal-exit": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-4.1.0.tgz",
+      "integrity": "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true
+    },
+    "node_modules/string-width": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-5.1.2.tgz",
+      "integrity": "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA==",
+      "dev": true,
+      "dependencies": {
+        "eastasianwidth": "^0.2.0",
+        "emoji-regex": "^9.2.2",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/string-width-cjs": {
+      "name": "string-width",
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/string-width-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/string-width-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/strip-ansi-cjs": {
+      "name": "strip-ansi",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true
+    },
+    "node_modules/test-exclude": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/test-exclude/-/test-exclude-7.0.2.tgz",
+      "integrity": "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw==",
+      "dev": true,
+      "dependencies": {
+        "@istanbuljs/schema": "^0.1.2",
+        "glob": "^10.4.1",
+        "minimatch": "^10.2.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-1.2.0.tgz",
+      "integrity": "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-3.0.2.tgz",
+      "integrity": "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==",
+      "dev": true,
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/vite": {
+      "version": "5.4.21",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-5.4.21.tgz",
+      "integrity": "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==",
+      "dev": true,
+      "dependencies": {
+        "esbuild": "^0.21.3",
+        "postcss": "^8.4.43",
+        "rollup": "^4.20.0"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vite-node": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-2.1.9.tgz",
+      "integrity": "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==",
+      "dev": true,
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.3.7",
+        "es-module-lexer": "^1.5.4",
+        "pathe": "^1.1.2",
+        "vite": "^5.0.0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "2.1.9",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-2.1.9.tgz",
+      "integrity": "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==",
+      "dev": true,
+      "dependencies": {
+        "@vitest/expect": "2.1.9",
+        "@vitest/mocker": "2.1.9",
+        "@vitest/pretty-format": "^2.1.9",
+        "@vitest/runner": "2.1.9",
+        "@vitest/snapshot": "2.1.9",
+        "@vitest/spy": "2.1.9",
+        "@vitest/utils": "2.1.9",
+        "chai": "^5.1.2",
+        "debug": "^4.3.7",
+        "expect-type": "^1.1.0",
+        "magic-string": "^0.30.12",
+        "pathe": "^1.1.2",
+        "std-env": "^3.8.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.1",
+        "tinypool": "^1.0.1",
+        "tinyrainbow": "^1.2.0",
+        "vite": "^5.0.0",
+        "vite-node": "2.1.9",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/node": "^18.0.0 || >=20.0.0",
+        "@vitest/browser": "2.1.9",
+        "@vitest/ui": "2.1.9",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "dev": true,
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi": {
+      "version": "8.1.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-8.1.0.tgz",
+      "integrity": "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^6.1.0",
+        "string-width": "^5.0.1",
+        "strip-ansi": "^7.0.1"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs": {
+      "name": "wrap-ansi",
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-7.0.0.tgz",
+      "integrity": "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.0.0",
+        "string-width": "^4.1.0",
+        "strip-ansi": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "dev": true
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dev": true,
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/wrap-ansi-cjs/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.0.tgz",
+      "integrity": "sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==",
+      "dev": true,
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true
+    }
+  }
+}

--- a/docs/showcase/package.json
+++ b/docs/showcase/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "tokemize-showcase",
+  "version": "1.0.0",
+  "description": "Tokemize GitHub Pages Showcase",
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
+  },
+  "devDependencies": {
+    "@vitest/coverage-v8": "^2.1.8",
+    "fast-check": "^3.22.0",
+    "jsdom": "^25.0.1",
+    "vitest": "^2.1.8"
+  }
+}

--- a/docs/showcase/style.css
+++ b/docs/showcase/style.css
@@ -1,0 +1,772 @@
+/* ============================================================
+   Tokemize Showcase — style.css
+   Dark theme, WCAG 2.1 AA (contrast ≥ 4.5:1), responsive
+   ============================================================ */
+
+/* ── CSS Custom Properties ─────────────────────────────────── */
+:root {
+  /* Colour palette — dark theme */
+  --color-bg:           #0d1117;   /* page background */
+  --color-surface:      #161b22;   /* card / section background */
+  --color-surface-alt:  #1c2128;   /* alternate surface */
+  --color-border:       #30363d;   /* subtle borders */
+
+  /* Text — all pairs verified ≥ 4.5:1 against their backgrounds */
+  --color-text-primary:   #e6edf3; /* on --color-bg / --color-surface  → ~13:1 */
+  --color-text-secondary: #8b949e; /* on --color-bg                    → ~4.6:1 */
+  --color-text-muted:     #6e7681; /* used only for decorative elements */
+
+  /* Brand / accent */
+  --color-accent:         #58a6ff; /* links, highlights on dark bg      → ~5.9:1 */
+  --color-accent-hover:   #79c0ff;
+  --color-success:        #3fb950; /* "done" badge on --color-surface   → ~4.6:1 */
+  --color-warning:        #d29922; /* "in_progress" badge               → ~4.5:1 */
+  --color-neutral:        #8b949e; /* "planned" badge                   → ~4.6:1 */
+  --color-error:          #f85149; /* error states                      → ~5.1:1 */
+
+  /* Typography */
+  --font-sans:   'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
+  --font-mono:   'JetBrains Mono', 'Fira Code', 'Cascadia Code', monospace;
+
+  --font-size-xs:   0.75rem;   /* 12px */
+  --font-size-sm:   0.875rem;  /* 14px */
+  --font-size-base: 1rem;      /* 16px */
+  --font-size-lg:   1.125rem;  /* 18px */
+  --font-size-xl:   1.25rem;   /* 20px */
+  --font-size-2xl:  1.5rem;    /* 24px */
+  --font-size-3xl:  2rem;      /* 32px */
+  --font-size-4xl:  2.5rem;    /* 40px */
+  --font-size-5xl:  3.5rem;    /* 56px */
+
+  --font-weight-normal:   400;
+  --font-weight-medium:   500;
+  --font-weight-semibold: 600;
+  --font-weight-bold:     700;
+
+  --line-height-tight:  1.25;
+  --line-height-normal: 1.5;
+  --line-height-loose:  1.75;
+
+  /* Spacing scale */
+  --space-1:  0.25rem;   /* 4px  */
+  --space-2:  0.5rem;    /* 8px  */
+  --space-3:  0.75rem;   /* 12px */
+  --space-4:  1rem;      /* 16px */
+  --space-5:  1.25rem;   /* 20px */
+  --space-6:  1.5rem;    /* 24px */
+  --space-8:  2rem;      /* 32px */
+  --space-10: 2.5rem;    /* 40px */
+  --space-12: 3rem;      /* 48px */
+  --space-16: 4rem;      /* 64px */
+  --space-20: 5rem;      /* 80px */
+  --space-24: 6rem;      /* 96px */
+
+  /* Layout */
+  --max-width:        1280px;
+  --section-padding:  var(--space-16) var(--space-6);
+
+  /* Borders & radius */
+  --radius-sm:  4px;
+  --radius-md:  8px;
+  --radius-lg:  12px;
+  --radius-xl:  16px;
+  --radius-full: 9999px;
+
+  /* Shadows */
+  --shadow-sm:  0 1px 3px rgba(0, 0, 0, 0.4);
+  --shadow-md:  0 4px 12px rgba(0, 0, 0, 0.5);
+  --shadow-lg:  0 8px 24px rgba(0, 0, 0, 0.6);
+
+  /* Transitions */
+  --transition-fast:   150ms ease;
+  --transition-normal: 250ms ease;
+}
+
+/* ── Modern CSS Reset ───────────────────────────────────────── */
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+}
+
+html {
+  scroll-behavior: smooth;
+  -webkit-text-size-adjust: 100%;
+  tab-size: 4;
+}
+
+body {
+  font-family: var(--font-sans);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-normal);
+  line-height: var(--line-height-normal);
+  color: var(--color-text-primary);
+  background-color: var(--color-bg);
+  min-height: 100vh;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+img,
+picture,
+video,
+canvas,
+svg {
+  display: block;
+  max-width: 100%;
+}
+
+input,
+button,
+textarea,
+select {
+  font: inherit;
+}
+
+p,
+h1,
+h2,
+h3,
+h4,
+h5,
+h6 {
+  overflow-wrap: break-word;
+}
+
+ul,
+ol {
+  list-style: none;
+}
+
+a {
+  color: var(--color-accent);
+  text-decoration: underline;
+  text-underline-offset: 3px;
+  transition: color var(--transition-fast);
+}
+
+a:hover,
+a:focus-visible {
+  color: var(--color-accent-hover);
+}
+
+/* ── Accessibility ──────────────────────────────────────────── */
+.skip-link {
+  position: absolute;
+  top: -100%;
+  left: var(--space-4);
+  z-index: 9999;
+  padding: var(--space-2) var(--space-4);
+  background: var(--color-accent);
+  color: var(--color-bg);
+  font-weight: var(--font-weight-semibold);
+  border-radius: var(--radius-md);
+  text-decoration: none;
+  transition: top var(--transition-fast);
+}
+
+.skip-link:focus {
+  top: var(--space-4);
+}
+
+:focus-visible {
+  outline: 2px solid var(--color-accent);
+  outline-offset: 3px;
+  border-radius: var(--radius-sm);
+}
+
+/* ── Layout Utilities ───────────────────────────────────────── */
+.section-inner {
+  max-width: var(--max-width);
+  margin-inline: auto;
+  padding: var(--section-padding);
+}
+
+.section-title {
+  font-size: var(--font-size-2xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-8);
+  padding-bottom: var(--space-3);
+  border-bottom: 1px solid var(--color-border);
+}
+
+/* ── Header / Navigation ────────────────────────────────────── */
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 100;
+  background-color: rgba(13, 17, 23, 0.92);
+  backdrop-filter: blur(8px);
+  -webkit-backdrop-filter: blur(8px);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.site-nav {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: var(--max-width);
+  margin-inline: auto;
+  padding: var(--space-4) var(--space-6);
+  gap: var(--space-6);
+}
+
+.nav-logo {
+  font-size: var(--font-size-xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  letter-spacing: -0.02em;
+  flex-shrink: 0;
+}
+
+.nav-logo:hover,
+.nav-logo:focus-visible {
+  color: var(--color-accent);
+}
+
+.nav-links {
+  display: flex;
+  align-items: center;
+  gap: var(--space-6);
+  flex-wrap: wrap;
+}
+
+.nav-links a {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+  transition: color var(--transition-fast);
+}
+
+.nav-links a:hover,
+.nav-links a:focus-visible {
+  color: var(--color-text-primary);
+}
+
+/* ── Hero Section ───────────────────────────────────────────── */
+#hero {
+  background: linear-gradient(
+    160deg,
+    var(--color-bg) 0%,
+    var(--color-surface) 100%
+  );
+  border-bottom: 1px solid var(--color-border);
+}
+
+#hero .section-inner {
+  padding-top: var(--space-24);
+  padding-bottom: var(--space-24);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-8);
+}
+
+.hero-title {
+  font-size: var(--font-size-5xl);
+  font-weight: var(--font-weight-bold);
+  letter-spacing: -0.04em;
+  line-height: var(--line-height-tight);
+  background: linear-gradient(135deg, var(--color-text-primary) 0%, var(--color-accent) 100%);
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: transparent;
+  background-clip: text;
+}
+
+.hero-tagline {
+  font-size: var(--font-size-xl);
+  color: var(--color-text-secondary);
+  max-width: 60ch;
+  line-height: var(--line-height-loose);
+}
+
+.hero-problems {
+  margin-top: var(--space-4);
+}
+
+.problems-heading {
+  font-size: var(--font-size-lg);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  margin-bottom: var(--space-4);
+}
+
+.problems-list {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-3);
+}
+
+.problems-list li {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: var(--font-size-base);
+  color: var(--color-text-secondary);
+}
+
+.problems-list li::before {
+  content: '';
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: var(--radius-full);
+  background-color: var(--color-error);
+  flex-shrink: 0;
+}
+
+/* ── Stats Section ──────────────────────────────────────────── */
+#stats {
+  background-color: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.stats-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: var(--space-4);
+}
+
+.stat-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+  transition: border-color var(--transition-normal);
+}
+
+.stat-card:hover {
+  border-color: var(--color-accent);
+}
+
+.stat-label {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.stat-value {
+  font-size: var(--font-size-3xl);
+  font-weight: var(--font-weight-bold);
+  color: var(--color-text-primary);
+  font-variant-numeric: tabular-nums;
+  line-height: var(--line-height-tight);
+}
+
+.stat-stale-indicator {
+  font-size: var(--font-size-xs);
+  color: var(--color-warning);
+  margin-top: var(--space-2);
+}
+
+.stats-stale-banner {
+  grid-column: 1 / -1;
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-4);
+  background-color: rgba(210, 153, 34, 0.1);
+  border: 1px solid rgba(210, 153, 34, 0.3);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-warning);
+}
+
+.stats-error {
+  grid-column: 1 / -1;
+  padding: var(--space-6);
+  background-color: rgba(248, 81, 73, 0.08);
+  border: 1px solid rgba(248, 81, 73, 0.25);
+  border-radius: var(--radius-md);
+  color: var(--color-error);
+  font-size: var(--font-size-sm);
+  text-align: center;
+}
+
+/* ── Contribution Graph Section ─────────────────────────────── */
+#contribution-graph {
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.graph-container {
+  background-color: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-6);
+  overflow-x: auto;
+}
+
+.graph-container svg {
+  min-width: 600px;
+  width: 100%;
+  height: auto;
+}
+
+.graph-tooltip {
+  position: fixed;
+  z-index: 200;
+  padding: var(--space-2) var(--space-3);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-md);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-primary);
+  pointer-events: none;
+  box-shadow: var(--shadow-md);
+  white-space: nowrap;
+  opacity: 0;
+  transition: opacity var(--transition-fast);
+}
+
+.graph-tooltip.visible {
+  opacity: 1;
+}
+
+/* ── Progress Section ───────────────────────────────────────── */
+#progress {
+  background-color: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.progress-overall {
+  margin-bottom: var(--space-8);
+}
+
+.progress-overall-label {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: var(--space-2);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.progress-bar-track {
+  height: 8px;
+  background-color: var(--color-surface);
+  border-radius: var(--radius-full);
+  overflow: hidden;
+  border: 1px solid var(--color-border);
+}
+
+.progress-bar-fill {
+  height: 100%;
+  background: linear-gradient(90deg, var(--color-accent) 0%, var(--color-success) 100%);
+  border-radius: var(--radius-full);
+  transition: width 0.6s ease;
+}
+
+.modules-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: var(--space-4);
+}
+
+.module-card {
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--space-3);
+}
+
+.module-label {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+}
+
+.module-badge {
+  font-size: var(--font-size-xs);
+  font-weight: var(--font-weight-semibold);
+  padding: var(--space-1) var(--space-3);
+  border-radius: var(--radius-full);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.module-badge--done {
+  background-color: rgba(63, 185, 80, 0.15);
+  color: var(--color-success);
+  border: 1px solid rgba(63, 185, 80, 0.3);
+}
+
+.module-badge--in_progress {
+  background-color: rgba(210, 153, 34, 0.15);
+  color: var(--color-warning);
+  border: 1px solid rgba(210, 153, 34, 0.3);
+}
+
+.module-badge--planned {
+  background-color: rgba(139, 148, 158, 0.15);
+  color: var(--color-neutral);
+  border: 1px solid rgba(139, 148, 158, 0.3);
+}
+
+/* ── Pipeline Section ───────────────────────────────────────── */
+#pipeline {
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.pipeline-flow {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: var(--space-4);
+}
+
+.pipeline-step {
+  background-color: var(--color-surface-alt);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-lg);
+  padding: var(--space-5) var(--space-8);
+  font-size: var(--font-size-base);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+  text-align: center;
+  min-width: 160px;
+  transition: border-color var(--transition-normal), box-shadow var(--transition-normal);
+}
+
+.pipeline-step:hover {
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-md);
+}
+
+.pipeline-step--highlight {
+  background: linear-gradient(135deg, rgba(88, 166, 255, 0.15) 0%, rgba(88, 166, 255, 0.05) 100%);
+  border-color: var(--color-accent);
+}
+
+.pipeline-arrow {
+  font-size: var(--font-size-2xl);
+  color: var(--color-text-muted);
+  user-select: none;
+  aria-hidden: true;
+}
+
+/* ── Tech Stack Section ─────────────────────────────────────── */
+#tech-stack {
+  background-color: var(--color-bg);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.tech-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+
+.tech-item a {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  background-color: var(--color-surface);
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-full);
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-medium);
+  color: var(--color-text-primary);
+  text-decoration: none;
+  transition: border-color var(--transition-fast), color var(--transition-fast), background-color var(--transition-fast);
+}
+
+.tech-item a:hover,
+.tech-item a:focus-visible {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background-color: rgba(88, 166, 255, 0.08);
+}
+
+/* ── Team Section ───────────────────────────────────────────── */
+#team {
+  background-color: var(--color-surface);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.team-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  gap: var(--space-6);
+}
+
+.team-member {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: var(--space-3);
+  text-align: center;
+}
+
+.team-avatar {
+  width: 80px;
+  height: 80px;
+  border-radius: var(--radius-full);
+  border: 2px solid var(--color-border);
+  object-fit: cover;
+  background-color: var(--color-surface-alt);
+  transition: border-color var(--transition-normal);
+}
+
+.team-member:hover .team-avatar {
+  border-color: var(--color-accent);
+}
+
+.team-name {
+  font-size: var(--font-size-sm);
+  font-weight: var(--font-weight-semibold);
+  color: var(--color-text-primary);
+}
+
+.team-github-link {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-secondary);
+  text-decoration: none;
+}
+
+.team-github-link:hover,
+.team-github-link:focus-visible {
+  color: var(--color-accent);
+  text-decoration: underline;
+}
+
+/* ── Footer ─────────────────────────────────────────────────── */
+.site-footer {
+  background-color: var(--color-bg);
+  border-top: 1px solid var(--color-border);
+  padding: var(--space-8) var(--space-6);
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.site-footer a {
+  color: var(--color-text-secondary);
+}
+
+.site-footer a:hover {
+  color: var(--color-accent);
+}
+
+/* ── Loading Placeholder ────────────────────────────────────── */
+.loading-placeholder {
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  padding: var(--space-8);
+  text-align: center;
+}
+
+/* ── Responsive — Tablet (≥ 768px) ─────────────────────────── */
+@media (min-width: 768px) {
+  .hero-title {
+    font-size: var(--font-size-5xl);
+  }
+
+  .hero-tagline {
+    font-size: var(--font-size-xl);
+  }
+
+  .problems-list {
+    flex-direction: row;
+    flex-wrap: wrap;
+    gap: var(--space-4);
+  }
+
+  .problems-list li {
+    flex: 1 1 auto;
+    min-width: 200px;
+  }
+}
+
+/* ── Responsive — Desktop (≥ 1280px) ───────────────────────── */
+@media (min-width: 1280px) {
+  .section-inner {
+    padding: var(--space-20) var(--space-8);
+  }
+
+  .hero-title {
+    font-size: clamp(3rem, 5vw, 4.5rem);
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(6, 1fr);
+  }
+
+  .team-list {
+    grid-template-columns: repeat(5, 1fr);
+  }
+}
+
+/* ── Responsive — Large screens (≥ 1920px) ─────────────────── */
+@media (min-width: 1920px) {
+  :root {
+    --max-width: 1600px;
+    --font-size-base: 1.0625rem;
+  }
+}
+
+/* ── Responsive — Mobile (≤ 375px) ─────────────────────────── */
+@media (max-width: 480px) {
+  :root {
+    --section-padding: var(--space-10) var(--space-4);
+  }
+
+  .hero-title {
+    font-size: var(--font-size-3xl);
+  }
+
+  .hero-tagline {
+    font-size: var(--font-size-base);
+  }
+
+  .site-nav {
+    flex-direction: column;
+    align-items: flex-start;
+    gap: var(--space-3);
+    padding: var(--space-3) var(--space-4);
+  }
+
+  .nav-links {
+    gap: var(--space-3);
+  }
+
+  .pipeline-flow {
+    flex-direction: column;
+  }
+
+  .pipeline-arrow {
+    transform: rotate(90deg);
+  }
+
+  .stats-grid {
+    grid-template-columns: repeat(2, 1fr);
+  }
+}
+
+/* ── Reduced Motion ─────────────────────────────────────────── */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}

--- a/docs/showcase/vitest.config.js
+++ b/docs/showcase/vitest.config.js
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'jsdom',
+    globals: false,
+  },
+});


### PR DESCRIPTION
## Resumo

Implementa uma página GitHub Pages estática para o projeto Tokemize, pensada para apresentações e demos. A página exibe estatísticas em tempo real do repositório, progresso de desenvolvimento por módulo, gráfico de contribuições, proposta de valor do produto e membros da equipe.

---

## O que foi adicionado

### Site estático (`docs/showcase/`)

| Arquivo | Responsabilidade |
|---|---|
| `index.html` | Shell HTML semântico com todas as seções |
| `style.css` | Dark theme, WCAG 2.1 AA (contraste ≥ 4.5:1), responsivo 375px–2560px |
| `app.js` | Orquestrador: config → render estático → API/cache → avatares |
| `config.json` | Dados declarativos do projeto (equipe, módulos, tech stack) |
| `configLoader.js` | Carrega `config.json` com fallback para `DEFAULT_CONFIG` |
| `cacheStore.js` | Cache `localStorage` com TTL de 1 hora |
| `apiClient.js` | GitHub REST API com `AbortController` timeout e `ApiError` |
| `assets/default-avatar.svg` | Avatar SVG padrão para membros sem foto |

### Componentes de UI (`docs/showcase/components/`)

- **`hero.js`** — título, tagline, lista de problemas e fluxo do pipeline
- **`stats.js`** — 6 métricas do repositório + indicador de dados desatualizados
- **`contributionGraph.js`** — gráfico SVG de barras com tooltip e `aria-label`
- **`progressTracker.js`** — barra de progresso geral + badges por módulo
- **`team.js`** — avatares GitHub + links de perfil dos 5 membros
- **`techStack.js`** — links para documentações das tecnologias

### Deploy automático (`.github/workflows/deploy.yml`)

- Trigger: push na branch `main`
- Publica `docs/showcase/` no branch `gh-pages` via `peaceiris/actions-gh-pages@v4`
- Timeout de 5 minutos; falha no build **não** sobrescreve a versão anterior publicada
- Validação do diretório antes do deploy

---

## Arquitetura

```
Browser
  └── app.js (orquestrador)
        ├── loadConfig()          → config.json (declarativo)
        ├── renderHero/TechStack/Progress/Team  → imediato, sem API
        └── ApiClient + CacheStore
              ├── fetchRepoStats()       → stats + cache 1h
              ├── fetchCommitActivity()  → gráfico + cache 1h
              └── fetchAvatarUrl()       → avatares da equipe
```

Resiliência: se a API falhar, usa cache stale com indicador visual. Se não há cache, exibe estado de erro amigável.

---

## Testes

**30 testes passando** (9 arquivos, Vitest + jsdom + fast-check)

| Tipo | Quantidade | Cobertura |
|---|---|---|
| Property-based (fast-check) | 16 | Propriedades P1–P16 do design |
| Unit tests | 14 | Casos específicos e edge cases |

Propriedades verificadas:

- **P1/P2:** `renderStats` exibe todos os campos e indicador stale
- **P3:** `CacheStore.isStale` respeita TTL de 1 hora
- **P4:** gráfico filtra exatamente as últimas 13 semanas
- **P5:** cores distintas por autor no gráfico
- **P6:** SVG com `aria-label` não vazio
- **P7/P8/P9:** `renderProgressTracker` — labels, percentual e prioridade do status manual
- **P10/P11:** `renderHero` e `renderTechStack` exibem todos os campos
- **P12/P13/P14:** `renderTeam` — nomes, links e avatares (presente/padrão)
- **P15/P16:** `loadConfig` round-trip e fallback para entradas inválidas

---

## Como ativar o GitHub Pages

1. Vá em **Settings → Pages** do repositório
2. Configure **Source** como branch `gh-pages`, pasta `/ (root)`
3. O primeiro deploy acontece automaticamente no próximo push para `main`

---

## Como atualizar o conteúdo

Edite `docs/showcase/config.json` e faça push para `main`. O deploy é automático.

---

## Testado

- [x] 30/30 testes passando (`npx vitest run` em `docs/showcase/`)
- [x] Workflow `deploy.yml` validado sintaticamente
- [x] `config.json` com campos ausentes exibe `DEFAULT_CONFIG` e emite `console.warn`
- [x] Fallback de avatar padrão funciona quando API não está disponível
