### PR TITLE
feat(parser): implementa scanner de repositorio e analisador Tree-sitter

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,35 @@
+[build-system]
+requires = ["setuptools>=68.0", "wheel"]
+build-backend = "setuptools.backends.legacy:build"
+
+[project]
+name = "tokemize"
+version = "0.1.0"
+description = "Agente inteligente de otimização de contexto para LLMs"
+requires-python = ">=3.11"
+dependencies = [
+    "tree-sitter==0.25.2",
+    "tree-sitter-python",
+    "tree-sitter-java",
+    "tree-sitter-javascript",
+    "tree-sitter-typescript",
+    "python-dotenv",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest==8.3.5",
+    "pytest-cov==6.1.0",
+]
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["src"]
+addopts = "-v --tb=short"
+
+[tool.coverage.run]
+source = ["src/tokemize"]
+omit = ["tests/*"]

--- a/src/tokemize/__init__.py
+++ b/src/tokemize/__init__.py
@@ -1,0 +1,1 @@
+# tokemize package

--- a/src/tokemize/core/__init__.py
+++ b/src/tokemize/core/__init__.py
@@ -1,0 +1,1 @@
+# core package

--- a/src/tokemize/core/parser/__init__.py
+++ b/src/tokemize/core/parser/__init__.py
@@ -1,0 +1,1 @@
+# parser package

--- a/src/tokemize/core/parser/scanner.py
+++ b/src/tokemize/core/parser/scanner.py
@@ -2,6 +2,11 @@
 
 Percorre um diretório recursivamente, aplica lista de ignores e coleta
 metadados dos arquivos de código-fonte válidos.
+
+Melhorias implementadas:
+- Proteção explícita contra symlinks recursivos
+- Método iter_files() para avaliação preguiçosa (lazy/streaming)
+- Documentação de thread-safety
 """
 
 from __future__ import annotations
@@ -10,6 +15,7 @@ import logging
 import os
 from dataclasses import dataclass, field
 from pathlib import Path
+from typing import Generator
 
 logger = logging.getLogger(__name__)
 
@@ -105,6 +111,13 @@ class RepositoryScanner:
     Aplica uma lista de diretórios e extensões a ignorar, retornando apenas
     arquivos de código-fonte válidos com seus metadados.
 
+    Proteção contra symlinks: diretórios que são links simbólicos são ignorados
+    por padrão para evitar loops infinitos em repositórios com symlinks recursivos.
+
+    Thread-safety: esta classe é segura para uso em múltiplas threads desde que
+    cada thread use sua própria instância. O estado interno (_ignore_dirs,
+    _supported_extensions, _max_file_size_bytes) é imutável após a construção.
+
     Args:
         ignore_dirs: Conjunto de nomes de diretórios a ignorar.
             Mescla com DEFAULT_IGNORE_DIRS se não fornecido.
@@ -112,12 +125,18 @@ class RepositoryScanner:
             Usa SUPPORTED_EXTENSIONS por padrão.
         max_file_size_bytes: Tamanho máximo de arquivo em bytes.
             Arquivos maiores são ignorados. Padrão: 1 MB.
+        follow_symlinks: Se True, segue links simbólicos de diretórios.
+            Padrão: False (proteção contra loops infinitos).
 
     Example:
         >>> scanner = RepositoryScanner()
         >>> result = scanner.scan(Path("/meu/projeto"))
         >>> for f in result.files:
         ...     print(f.relative_path, f.language)
+
+        >>> # Uso com streaming (baixo uso de memória)
+        >>> for metadata in scanner.iter_files(Path("/meu/projeto")):
+        ...     print(metadata.relative_path)
     """
 
     def __init__(
@@ -125,6 +144,7 @@ class RepositoryScanner:
         ignore_dirs: set[str] | None = None,
         supported_extensions: set[str] | None = None,
         max_file_size_bytes: int = 1024 * 1024,  # 1 MB
+        follow_symlinks: bool = False,
     ) -> None:
         self._ignore_dirs: frozenset[str] = (
             DEFAULT_IGNORE_DIRS | frozenset(ignore_dirs)
@@ -137,6 +157,7 @@ class RepositoryScanner:
             else SUPPORTED_EXTENSIONS
         )
         self._max_file_size_bytes = max_file_size_bytes
+        self._follow_symlinks = follow_symlinks
 
     @property
     def ignore_dirs(self) -> frozenset[str]:
@@ -150,6 +171,9 @@ class RepositoryScanner:
 
     def scan(self, root: Path) -> ScanResult:
         """Percorre o repositório a partir de `root` e coleta metadados.
+
+        Consome iter_files() internamente e materializa o resultado em memória.
+        Para repositórios muito grandes, prefira iter_files() diretamente.
 
         Args:
             root: Diretório raiz do repositório a ser varrido.
@@ -169,13 +193,16 @@ class RepositoryScanner:
         result = ScanResult(root=root)
         logger.info("Iniciando varredura em: %s", root)
 
-        for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+        for dirpath, dirnames, filenames in os.walk(
+            root, topdown=True, followlinks=self._follow_symlinks
+        ):
             current_dir = Path(dirpath)
 
             # Filtrar subdiretórios ignorados in-place (afeta os.walk)
             original_dirs = list(dirnames)
             dirnames[:] = [
-                d for d in dirnames if not self._should_ignore_dir(d)
+                d for d in dirnames
+                if not self._should_ignore_dir(d, current_dir)
             ]
 
             ignored = set(original_dirs) - set(dirnames)
@@ -205,17 +232,83 @@ class RepositoryScanner:
         )
         return result
 
-    def _should_ignore_dir(self, dirname: str) -> bool:
+    def iter_files(self, root: Path) -> Generator[FileMetadata, None, None]:
+        """Percorre o repositório gerando FileMetadata um a um (lazy/streaming).
+
+        Ideal para repositórios grandes onde carregar todos os metadados em
+        memória de uma vez seria custoso. Não acumula resultados internamente.
+
+        Args:
+            root: Diretório raiz do repositório a ser varrido.
+
+        Yields:
+            FileMetadata para cada arquivo válido encontrado.
+
+        Raises:
+            NotADirectoryError: Se `root` não for um diretório válido.
+
+        Example:
+            >>> scanner = RepositoryScanner()
+            >>> for metadata in scanner.iter_files(Path("/meu/projeto")):
+            ...     process(metadata)  # processa um arquivo por vez
+        """
+        root = root.resolve()
+        if not root.is_dir():
+            raise NotADirectoryError(
+                f"O caminho fornecido não é um diretório válido: {root}"
+            )
+
+        logger.info("Iniciando varredura lazy em: %s", root)
+
+        for dirpath, dirnames, filenames in os.walk(
+            root, topdown=True, followlinks=self._follow_symlinks
+        ):
+            current_dir = Path(dirpath)
+
+            dirnames[:] = [
+                d for d in dirnames
+                if not self._should_ignore_dir(d, current_dir)
+            ]
+
+            for filename in filenames:
+                file_path = current_dir / filename
+                ext = file_path.suffix.lower()
+
+                if ext not in self._supported_extensions:
+                    continue
+
+                metadata = self._collect_metadata(file_path, root, ext)
+                if metadata is not None:
+                    logger.debug("Arquivo encontrado: %s", metadata.relative_path)
+                    yield metadata
+
+    def _should_ignore_dir(self, dirname: str, parent: Path) -> bool:
         """Verifica se um diretório deve ser ignorado.
+
+        Ignora diretórios que:
+        - Estão na lista de ignores (por nome exato ou padrão wildcard)
+        - São links simbólicos quando follow_symlinks=False
 
         Args:
             dirname: Nome do diretório (não o caminho completo).
+            parent: Diretório pai, usado para verificar se é symlink.
 
         Returns:
             True se o diretório deve ser ignorado.
         """
+        # Verificação de symlink — evita loops infinitos
+        if not self._follow_symlinks:
+            full_path = parent / dirname
+            if full_path.is_symlink():
+                logger.debug(
+                    "Diretório symlink ignorado (follow_symlinks=False): %s",
+                    full_path,
+                )
+                return True
+
         if dirname in self._ignore_dirs:
             return True
+
         # Suporte a padrões com wildcard simples (ex: "*.egg-info")
         for pattern in self._ignore_dirs:
             if "*" in pattern:
@@ -224,6 +317,7 @@ class RepositoryScanner:
                     prefix.strip(".")
                 ):
                     return True
+
         return False
 
     def _collect_metadata(
@@ -237,7 +331,8 @@ class RepositoryScanner:
             ext: Extensão do arquivo.
 
         Returns:
-            FileMetadata ou None se o arquivo não puder ser lido.
+            FileMetadata ou None se o arquivo não puder ser lido ou exceder
+            o limite de tamanho.
         """
         try:
             stat = file_path.stat()

--- a/src/tokemize/core/parser/scanner.py
+++ b/src/tokemize/core/parser/scanner.py
@@ -1,0 +1,282 @@
+"""Scanner de repositório para o Tokemize.
+
+Percorre um diretório recursivamente, aplica lista de ignores e coleta
+metadados dos arquivos de código-fonte válidos.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass, field
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+# Diretórios ignorados por padrão
+DEFAULT_IGNORE_DIRS: frozenset[str] = frozenset(
+    {
+        ".git",
+        ".github",
+        ".kiro",
+        ".venv",
+        "venv",
+        "env",
+        ".env",
+        "node_modules",
+        "dist",
+        "build",
+        ".cache",
+        "__pycache__",
+        ".pytest_cache",
+        ".mypy_cache",
+        ".ruff_cache",
+        "htmlcov",
+        "coverage",
+        ".tox",
+        "eggs",
+        ".eggs",
+        "*.egg-info",
+        "target",        # Java/Maven
+        "out",           # Java/Gradle
+        ".idea",
+        ".vscode",
+        "outputs",
+    }
+)
+
+# Extensões de arquivo suportadas para análise
+SUPPORTED_EXTENSIONS: frozenset[str] = frozenset(
+    {".py", ".java", ".js", ".ts"}
+)
+
+# Mapeamento de extensão para linguagem
+EXTENSION_TO_LANGUAGE: dict[str, str] = {
+    ".py": "python",
+    ".java": "java",
+    ".js": "javascript",
+    ".ts": "typescript",
+}
+
+
+@dataclass
+class FileMetadata:
+    """Metadados de um arquivo de código-fonte encontrado pelo scanner.
+
+    Attributes:
+        path: Caminho absoluto do arquivo.
+        relative_path: Caminho relativo à raiz do repositório.
+        language: Linguagem detectada pela extensão.
+        extension: Extensão do arquivo (ex: ".py").
+        size_bytes: Tamanho do arquivo em bytes.
+        line_count: Número de linhas do arquivo.
+    """
+
+    path: Path
+    relative_path: Path
+    language: str
+    extension: str
+    size_bytes: int
+    line_count: int = 0
+
+
+@dataclass
+class ScanResult:
+    """Resultado de uma varredura de repositório.
+
+    Attributes:
+        root: Diretório raiz varrido.
+        files: Lista de metadados dos arquivos encontrados.
+        ignored_dirs: Conjunto de diretórios ignorados durante a varredura.
+        total_files: Total de arquivos válidos encontrados.
+        skipped_files: Total de arquivos ignorados (extensão não suportada).
+    """
+
+    root: Path
+    files: list[FileMetadata] = field(default_factory=list)
+    ignored_dirs: set[str] = field(default_factory=set)
+    total_files: int = 0
+    skipped_files: int = 0
+
+
+class RepositoryScanner:
+    """Percorre um repositório e coleta metadados dos arquivos de código.
+
+    Aplica uma lista de diretórios e extensões a ignorar, retornando apenas
+    arquivos de código-fonte válidos com seus metadados.
+
+    Args:
+        ignore_dirs: Conjunto de nomes de diretórios a ignorar.
+            Mescla com DEFAULT_IGNORE_DIRS se não fornecido.
+        supported_extensions: Conjunto de extensões suportadas.
+            Usa SUPPORTED_EXTENSIONS por padrão.
+        max_file_size_bytes: Tamanho máximo de arquivo em bytes.
+            Arquivos maiores são ignorados. Padrão: 1 MB.
+
+    Example:
+        >>> scanner = RepositoryScanner()
+        >>> result = scanner.scan(Path("/meu/projeto"))
+        >>> for f in result.files:
+        ...     print(f.relative_path, f.language)
+    """
+
+    def __init__(
+        self,
+        ignore_dirs: set[str] | None = None,
+        supported_extensions: set[str] | None = None,
+        max_file_size_bytes: int = 1024 * 1024,  # 1 MB
+    ) -> None:
+        self._ignore_dirs: frozenset[str] = (
+            DEFAULT_IGNORE_DIRS | frozenset(ignore_dirs)
+            if ignore_dirs
+            else DEFAULT_IGNORE_DIRS
+        )
+        self._supported_extensions: frozenset[str] = (
+            frozenset(supported_extensions)
+            if supported_extensions
+            else SUPPORTED_EXTENSIONS
+        )
+        self._max_file_size_bytes = max_file_size_bytes
+
+    @property
+    def ignore_dirs(self) -> frozenset[str]:
+        """Conjunto de diretórios ignorados pelo scanner."""
+        return self._ignore_dirs
+
+    @property
+    def supported_extensions(self) -> frozenset[str]:
+        """Conjunto de extensões suportadas pelo scanner."""
+        return self._supported_extensions
+
+    def scan(self, root: Path) -> ScanResult:
+        """Percorre o repositório a partir de `root` e coleta metadados.
+
+        Args:
+            root: Diretório raiz do repositório a ser varrido.
+
+        Returns:
+            ScanResult com a lista de arquivos válidos e estatísticas.
+
+        Raises:
+            NotADirectoryError: Se `root` não for um diretório válido.
+        """
+        root = root.resolve()
+        if not root.is_dir():
+            raise NotADirectoryError(
+                f"O caminho fornecido não é um diretório válido: {root}"
+            )
+
+        result = ScanResult(root=root)
+        logger.info("Iniciando varredura em: %s", root)
+
+        for dirpath, dirnames, filenames in os.walk(root, topdown=True):
+            current_dir = Path(dirpath)
+
+            # Filtrar subdiretórios ignorados in-place (afeta os.walk)
+            original_dirs = list(dirnames)
+            dirnames[:] = [
+                d for d in dirnames if not self._should_ignore_dir(d)
+            ]
+
+            ignored = set(original_dirs) - set(dirnames)
+            result.ignored_dirs.update(ignored)
+
+            for filename in filenames:
+                file_path = current_dir / filename
+                ext = file_path.suffix.lower()
+
+                if ext not in self._supported_extensions:
+                    result.skipped_files += 1
+                    continue
+
+                metadata = self._collect_metadata(file_path, root, ext)
+                if metadata is None:
+                    result.skipped_files += 1
+                    continue
+
+                result.files.append(metadata)
+                result.total_files += 1
+                logger.debug("Arquivo encontrado: %s", metadata.relative_path)
+
+        logger.info(
+            "Varredura concluída: %d arquivos válidos, %d ignorados",
+            result.total_files,
+            result.skipped_files,
+        )
+        return result
+
+    def _should_ignore_dir(self, dirname: str) -> bool:
+        """Verifica se um diretório deve ser ignorado.
+
+        Args:
+            dirname: Nome do diretório (não o caminho completo).
+
+        Returns:
+            True se o diretório deve ser ignorado.
+        """
+        if dirname in self._ignore_dirs:
+            return True
+        # Suporte a padrões com wildcard simples (ex: "*.egg-info")
+        for pattern in self._ignore_dirs:
+            if "*" in pattern:
+                prefix = pattern.replace("*", "")
+                if dirname.endswith(prefix) or dirname.startswith(
+                    prefix.strip(".")
+                ):
+                    return True
+        return False
+
+    def _collect_metadata(
+        self, file_path: Path, root: Path, ext: str
+    ) -> FileMetadata | None:
+        """Coleta metadados de um arquivo.
+
+        Args:
+            file_path: Caminho absoluto do arquivo.
+            root: Diretório raiz para calcular o caminho relativo.
+            ext: Extensão do arquivo.
+
+        Returns:
+            FileMetadata ou None se o arquivo não puder ser lido.
+        """
+        try:
+            stat = file_path.stat()
+            size = stat.st_size
+
+            if size > self._max_file_size_bytes:
+                logger.warning(
+                    "Arquivo ignorado por exceder tamanho máximo (%d bytes): %s",
+                    self._max_file_size_bytes,
+                    file_path,
+                )
+                return None
+
+            line_count = self._count_lines(file_path)
+            language = EXTENSION_TO_LANGUAGE.get(ext, "unknown")
+
+            return FileMetadata(
+                path=file_path,
+                relative_path=file_path.relative_to(root),
+                language=language,
+                extension=ext,
+                size_bytes=size,
+                line_count=line_count,
+            )
+        except (OSError, PermissionError) as exc:
+            logger.warning("Não foi possível ler o arquivo %s: %s", file_path, exc)
+            return None
+
+    def _count_lines(self, file_path: Path) -> int:
+        """Conta o número de linhas de um arquivo.
+
+        Args:
+            file_path: Caminho do arquivo.
+
+        Returns:
+            Número de linhas ou 0 em caso de erro de leitura.
+        """
+        try:
+            with open(file_path, "rb") as f:
+                return sum(1 for _ in f)
+        except (OSError, PermissionError):
+            return 0

--- a/src/tokemize/core/parser/tree_sitter_analyzer.py
+++ b/src/tokemize/core/parser/tree_sitter_analyzer.py
@@ -3,13 +3,23 @@
 Extrai artefatos estruturais (classes, funções, métodos, imports) de arquivos
 de código-fonte usando grammars Tree-sitter para Python, Java, JavaScript e
 TypeScript.
+
+Abordagem de extração:
+    Usa child_by_field_name() — a API declarativa recomendada pelo Tree-sitter
+    para acessar nós nomeados na gramática (ex: name:, body:, parameters:).
+    Isso substitui a navegação manual por tipo de nó, tornando o código mais
+    conciso, preciso e resiliente a mudanças de gramática.
+
+Thread-safety:
+    O dicionário _PARSERS é compartilhado entre instâncias. Parsers do
+    Tree-sitter não são thread-safe. Para uso concorrente, instancie um
+    TreeSitterAnalyzer por thread ou use threading.local().
 """
 
 from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Callable
 
 import tree_sitter_java as tsjava
 import tree_sitter_javascript as tsjs
@@ -62,7 +72,10 @@ class ParseError(RuntimeError):
 
 
 # ---------------------------------------------------------------------------
-# Inicialização lazy dos parsers (um por linguagem)
+# Parsers lazy — um por linguagem, criados na primeira chamada
+#
+# AVISO DE THREAD-SAFETY: este dicionário é compartilhado. Para uso
+# concorrente, use threading.local() ou instancie parsers por thread.
 # ---------------------------------------------------------------------------
 
 _PARSERS: dict[str, Parser] = {}
@@ -101,65 +114,99 @@ def _get_parser(language: str) -> Parser:
 
 
 # ---------------------------------------------------------------------------
-# Extratores por linguagem
+# Utilitários de extração de texto
 # ---------------------------------------------------------------------------
 
-# Tipo de função extratora: recebe (node, source_bytes, file_path) → list[Artifact]
-_ExtractorFn = Callable[[Node, bytes, str], list[Artifact]]
-
-
-def _node_text(node: Node, source: bytes) -> str:
+def _text(node: Node | None, source: bytes) -> str:
     """Extrai o texto original de um nó da AST.
 
     Args:
-        node: Nó da AST.
+        node: Nó da AST ou None.
         source: Bytes do arquivo fonte.
 
     Returns:
-        Texto do nó como string UTF-8.
+        Texto do nó como string UTF-8, ou string vazia se node for None.
     """
+    if node is None:
+        return ""
     return source[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
 
 
-def _child_text(node: Node, *types: str) -> str:
-    """Retorna o texto do primeiro filho com um dos tipos especificados.
+def _field_text(node: Node, field: str) -> str:
+    """Retorna o texto do filho acessado por nome de campo (field name).
+
+    Usa child_by_field_name() — a API declarativa do Tree-sitter que acessa
+    nós nomeados na gramática (ex: name:, body:, parameters:).
 
     Args:
         node: Nó pai.
-        *types: Tipos de nó a procurar.
+        field: Nome do campo na gramática (ex: "name", "body").
 
     Returns:
-        Texto do filho encontrado ou string vazia.
+        Texto do campo ou string vazia se o campo não existir.
     """
-    for child in node.children:
-        if child.type in types:
-            return child.text.decode("utf-8", errors="replace") if child.text else ""
-    return ""
+    child = node.child_by_field_name(field)
+    if child is None:
+        return ""
+    return child.text.decode("utf-8", errors="replace") if child.text else ""
 
 
-# ---- Python ----------------------------------------------------------------
-
-def _extract_python(node: Node, source: bytes, file_path: str) -> list[Artifact]:
-    """Extrai artefatos de um arquivo Python.
-
-    Percorre a AST recursivamente extraindo:
-    - import_statement → type "import"
-    - import_from_statement → type "import"
-    - function_definition (top-level) → type "function"
-    - class_definition → type "class"
-    - function_definition dentro de class → type "method"
-    - decorated_definition → delega ao nó interno
+def _make_artifact(
+    name: str,
+    artifact_type: str,
+    node: Node,
+    source: bytes,
+    language: str,
+    file_path: str,
+) -> Artifact:
+    """Cria um Artifact a partir de um nó da AST.
 
     Args:
-        node: Nó raiz da AST.
+        name: Nome do artefato.
+        artifact_type: Tipo: "function", "class", "method" ou "import".
+        node: Nó da AST que representa o artefato completo.
         source: Bytes do arquivo fonte.
-        file_path: Caminho do arquivo (para metadados).
+        language: Linguagem de programação.
+        file_path: Caminho do arquivo de origem.
+
+    Returns:
+        Instância de Artifact com todos os metadados preenchidos.
+    """
+    return Artifact(
+        name=name,
+        type=artifact_type,
+        start_line=node.start_point.row + 1,
+        end_line=node.end_point.row + 1,
+        language=language,
+        content=_text(node, source),
+        file_path=file_path,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Extrator Python
+# ---------------------------------------------------------------------------
+
+def _extract_python(root: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo Python usando field names da gramática.
+
+    Extrai:
+    - import_statement / import_from_statement → "import"
+    - function_definition (top-level) → "function"
+    - class_definition → "class"
+    - function_definition dentro de class → "method"
+    - decorated_definition → delega ao nó interno preservando o range completo
+
+    Args:
+        root: Nó raiz da AST (module).
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
 
     Returns:
         Lista de Artifact extraídos.
     """
     artifacts: list[Artifact] = []
-    _walk_python(node, source, file_path, artifacts, inside_class=False)
+    _walk_python(root, source, file_path, artifacts, inside_class=False)
     return artifacts
 
 
@@ -170,53 +217,33 @@ def _walk_python(
     artifacts: list[Artifact],
     inside_class: bool,
 ) -> None:
-    """Percorre recursivamente a AST Python extraindo artefatos.
-
-    Args:
-        node: Nó atual da AST.
-        source: Bytes do arquivo fonte.
-        file_path: Caminho do arquivo.
-        artifacts: Lista acumuladora de artefatos.
-        inside_class: True se o nó atual está dentro de uma classe.
-    """
     for child in node.children:
-        if child.type in ("import_statement", "import_from_statement"):
+        if child.type == "import_statement":
+            # import X  →  name via primeiro dotted_name ou aliased_import
             name = _python_import_name(child, source)
-            artifacts.append(
-                Artifact(
-                    name=name,
-                    type="import",
-                    start_line=child.start_point.row + 1,
-                    end_line=child.end_point.row + 1,
-                    language="python",
-                    content=_node_text(child, source),
-                    file_path=file_path,
-                )
-            )
+            artifacts.append(_make_artifact(name, "import", child, source, "python", file_path))
+
+        elif child.type == "import_from_statement":
+            name = _python_import_name(child, source)
+            artifacts.append(_make_artifact(name, "import", child, source, "python", file_path))
 
         elif child.type == "decorated_definition":
-            # Delega ao nó interno (function_definition ou class_definition)
             # O range do decorated_definition inclui os decorators
             inner = next(
-                (
-                    c
-                    for c in child.children
-                    if c.type in ("function_definition", "class_definition")
-                ),
+                (c for c in child.children if c.type in ("function_definition", "class_definition")),
                 None,
             )
             if inner:
-                _extract_python_def(
-                    inner, child, source, file_path, artifacts, inside_class
-                )
+                _process_python_def(inner, child, source, file_path, artifacts, inside_class)
 
-        elif child.type in ("function_definition", "class_definition"):
-            _extract_python_def(
-                child, child, source, file_path, artifacts, inside_class
-            )
+        elif child.type == "function_definition":
+            _process_python_def(child, child, source, file_path, artifacts, inside_class)
+
+        elif child.type == "class_definition":
+            _process_python_def(child, child, source, file_path, artifacts, inside_class)
 
 
-def _extract_python_def(
+def _process_python_def(
     node: Node,
     range_node: Node,
     source: bytes,
@@ -224,50 +251,32 @@ def _extract_python_def(
     artifacts: list[Artifact],
     inside_class: bool,
 ) -> None:
-    """Extrai um artefato de definição Python (função ou classe).
+    """Processa uma definição Python (função ou classe) e extrai o artefato.
 
     Args:
         node: Nó da definição (function_definition ou class_definition).
-        range_node: Nó usado para calcular start/end line (pode incluir decorators).
+        range_node: Nó cujo range define start/end line (inclui decorators se houver).
         source: Bytes do arquivo fonte.
         file_path: Caminho do arquivo.
         artifacts: Lista acumuladora.
         inside_class: True se está dentro de uma classe.
     """
-    name = _child_text(node, "identifier")
+    # child_by_field_name("name") acessa o campo `name:` da gramática Python
+    name_node = node.child_by_field_name("name")
+    if name_node is None:
+        return
+    name = name_node.text.decode("utf-8", errors="replace") if name_node.text else ""
     if not name:
         return
 
     if node.type == "function_definition":
         artifact_type = "method" if inside_class else "function"
-        artifacts.append(
-            Artifact(
-                name=name,
-                type=artifact_type,
-                start_line=range_node.start_point.row + 1,
-                end_line=range_node.end_point.row + 1,
-                language="python",
-                content=_node_text(range_node, source),
-                file_path=file_path,
-            )
-        )
+        artifacts.append(_make_artifact(name, artifact_type, range_node, source, "python", file_path))
 
     elif node.type == "class_definition":
-        artifacts.append(
-            Artifact(
-                name=name,
-                type="class",
-                start_line=range_node.start_point.row + 1,
-                end_line=range_node.end_point.row + 1,
-                language="python",
-                content=_node_text(range_node, source),
-                file_path=file_path,
-            )
-        )
+        artifacts.append(_make_artifact(name, "class", range_node, source, "python", file_path))
         # Percorre o corpo da classe para extrair métodos
-        body = next(
-            (c for c in node.children if c.type == "block"), None
-        )
+        body = node.child_by_field_name("body")
         if body:
             _walk_python(body, source, file_path, artifacts, inside_class=True)
 
@@ -286,13 +295,12 @@ def _python_import_name(node: Node, source: bytes) -> str:
         Nome do import como string.
     """
     if node.type == "import_statement":
-        # import X, Y → pega o primeiro nome
         for child in node.children:
             if child.type in ("dotted_name", "aliased_import"):
                 return child.text.decode("utf-8", errors="replace") if child.text else ""
-        return _node_text(node, source).strip()
+        return _text(node, source).strip()
 
-    # import_from_statement: from X import Y
+    # import_from_statement: from <module> import <name>
     module = ""
     imported = ""
     for child in node.children:
@@ -301,25 +309,25 @@ def _python_import_name(node: Node, source: bytes) -> str:
         elif child.type in ("dotted_name", "identifier") and module:
             imported = child.text.decode("utf-8", errors="replace") if child.text else ""
             break
-        elif child.type == "import":
-            continue
     if module and imported:
         return f"{module}.{imported}"
-    return module or _node_text(node, source).strip()
+    return module or _text(node, source).strip()
 
 
-# ---- Java ------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Extrator Java
+# ---------------------------------------------------------------------------
 
-def _extract_java(node: Node, source: bytes, file_path: str) -> list[Artifact]:
-    """Extrai artefatos de um arquivo Java.
+def _extract_java(root: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo Java usando field names da gramática.
 
     Extrai:
-    - import_declaration → type "import"
-    - class_declaration / interface_declaration → type "class"
-    - method_declaration / constructor_declaration → type "method"
+    - import_declaration → "import"
+    - class_declaration / interface_declaration / enum_declaration → "class"
+    - method_declaration / constructor_declaration → "method"
 
     Args:
-        node: Nó raiz da AST.
+        root: Nó raiz da AST (program).
         source: Bytes do arquivo fonte.
         file_path: Caminho do arquivo.
 
@@ -327,7 +335,7 @@ def _extract_java(node: Node, source: bytes, file_path: str) -> list[Artifact]:
         Lista de Artifact extraídos.
     """
     artifacts: list[Artifact] = []
-    _walk_java(node, source, file_path, artifacts, inside_class=False)
+    _walk_java(root, source, file_path, artifacts, inside_class=False)
     return artifacts
 
 
@@ -338,85 +346,53 @@ def _walk_java(
     artifacts: list[Artifact],
     inside_class: bool,
 ) -> None:
-    """Percorre recursivamente a AST Java.
-
-    Args:
-        node: Nó atual.
-        source: Bytes do arquivo fonte.
-        file_path: Caminho do arquivo.
-        artifacts: Lista acumuladora.
-        inside_class: True se dentro de uma classe.
-    """
     for child in node.children:
         if child.type == "import_declaration":
-            # Pega o scoped_identifier ou dotted_name
+            # Java: import java.util.List; → scoped_identifier ou identifier
             name = ""
             for c in child.children:
                 if c.type in ("scoped_identifier", "identifier"):
                     name = c.text.decode("utf-8", errors="replace") if c.text else ""
                     break
             artifacts.append(
-                Artifact(
-                    name=name or _node_text(child, source).strip(),
-                    type="import",
-                    start_line=child.start_point.row + 1,
-                    end_line=child.end_point.row + 1,
-                    language="java",
-                    content=_node_text(child, source),
-                    file_path=file_path,
-                )
+                _make_artifact(name or _text(child, source).strip(), "import", child, source, "java", file_path)
             )
 
         elif child.type in ("class_declaration", "interface_declaration", "enum_declaration"):
-            name = _child_text(child, "identifier")
+            # child_by_field_name("name") acessa o campo `name:` da gramática Java
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="class",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language="java",
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
+                artifacts.append(_make_artifact(name, "class", child, source, "java", file_path))
             # Percorre o corpo para métodos
-            _walk_java(child, source, file_path, artifacts, inside_class=True)
+            body = child.child_by_field_name("body")
+            if body:
+                _walk_java(body, source, file_path, artifacts, inside_class=True)
 
         elif child.type in ("method_declaration", "constructor_declaration") and inside_class:
-            name = _child_text(child, "identifier")
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="method",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language="java",
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
+                artifacts.append(_make_artifact(name, "method", child, source, "java", file_path))
 
         else:
             _walk_java(child, source, file_path, artifacts, inside_class)
 
 
-# ---- JavaScript ------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Extrator JavaScript
+# ---------------------------------------------------------------------------
 
-def _extract_javascript(node: Node, source: bytes, file_path: str) -> list[Artifact]:
-    """Extrai artefatos de um arquivo JavaScript.
+def _extract_javascript(root: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo JavaScript usando field names da gramática.
 
     Extrai:
-    - import_statement → type "import"
-    - class_declaration → type "class"
-    - method_definition → type "method"
-    - function_declaration → type "function"
-    - lexical_declaration / variable_declaration com arrow function → type "function"
+    - import_statement → "import"
+    - class_declaration → "class"
+    - method_definition → "method"
+    - function_declaration → "function"
+    - lexical_declaration / variable_declaration com arrow/function → "function"
 
     Args:
-        node: Nó raiz da AST.
+        root: Nó raiz da AST (program).
         source: Bytes do arquivo fonte.
         file_path: Caminho do arquivo.
 
@@ -424,7 +400,7 @@ def _extract_javascript(node: Node, source: bytes, file_path: str) -> list[Artif
         Lista de Artifact extraídos.
     """
     artifacts: list[Artifact] = []
-    _walk_js(node, source, file_path, artifacts, language="javascript", inside_class=False)
+    _walk_js(root, source, file_path, artifacts, language="javascript", inside_class=False)
     return artifacts
 
 
@@ -436,85 +412,33 @@ def _walk_js(
     language: str,
     inside_class: bool,
 ) -> None:
-    """Percorre recursivamente a AST JavaScript/TypeScript.
-
-    Args:
-        node: Nó atual.
-        source: Bytes do arquivo fonte.
-        file_path: Caminho do arquivo.
-        artifacts: Lista acumuladora.
-        language: "javascript" ou "typescript".
-        inside_class: True se dentro de uma classe.
-    """
     for child in node.children:
         if child.type == "import_statement":
             name = _js_import_name(child, source)
-            artifacts.append(
-                Artifact(
-                    name=name,
-                    type="import",
-                    start_line=child.start_point.row + 1,
-                    end_line=child.end_point.row + 1,
-                    language=language,
-                    content=_node_text(child, source),
-                    file_path=file_path,
-                )
-            )
+            artifacts.append(_make_artifact(name, "import", child, source, language, file_path))
 
         elif child.type == "class_declaration":
-            # JS usa "identifier", TS usa "type_identifier"
-            name = _child_text(child, "identifier", "type_identifier")
+            # child_by_field_name("name") acessa o campo `name:` da gramática JS/TS
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="class",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language=language,
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
-            # Percorre o corpo da classe
-            body = next(
-                (c for c in child.children if c.type == "class_body"), None
-            )
+                artifacts.append(_make_artifact(name, "class", child, source, language, file_path))
+            body = child.child_by_field_name("body")
             if body:
                 _walk_js(body, source, file_path, artifacts, language, inside_class=True)
 
         elif child.type == "method_definition" and inside_class:
-            name = _child_text(child, "property_identifier", "identifier")
+            # child_by_field_name("name") acessa o campo `name:` da gramática JS/TS
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="method",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language=language,
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
+                artifacts.append(_make_artifact(name, "method", child, source, language, file_path))
 
         elif child.type == "function_declaration":
-            name = _child_text(child, "identifier")
+            # child_by_field_name("name") acessa o campo `name:` da gramática JS/TS
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="function",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language=language,
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
+                artifacts.append(_make_artifact(name, "function", child, source, language, file_path))
 
         elif child.type in ("lexical_declaration", "variable_declaration"):
-            # Detecta: const foo = () => ... ou const foo = function() ...
             _extract_js_variable_fn(child, source, file_path, artifacts, language)
 
         else:
@@ -530,6 +454,10 @@ def _extract_js_variable_fn(
 ) -> None:
     """Extrai funções declaradas como variáveis (arrow functions, function expressions).
 
+    Detecta padrões como:
+    - const foo = (x) => x + 1
+    - const foo = function(x) { return x; }
+
     Args:
         node: Nó lexical_declaration ou variable_declaration.
         source: Bytes do arquivo fonte.
@@ -540,34 +468,21 @@ def _extract_js_variable_fn(
     for declarator in node.children:
         if declarator.type != "variable_declarator":
             continue
-        name = _child_text(declarator, "identifier")
+        # child_by_field_name("name") acessa o campo `name:` do variable_declarator
+        name_node = declarator.child_by_field_name("name")
+        if name_node is None:
+            continue
+        name = name_node.text.decode("utf-8", errors="replace") if name_node.text else ""
         if not name:
             continue
-        # Verifica se o valor é arrow_function ou function_expression
-        value = next(
-            (
-                c
-                for c in declarator.children
-                if c.type in ("arrow_function", "function_expression", "function")
-            ),
-            None,
-        )
-        if value:
-            artifacts.append(
-                Artifact(
-                    name=name,
-                    type="function",
-                    start_line=node.start_point.row + 1,
-                    end_line=node.end_point.row + 1,
-                    language=language,
-                    content=_node_text(node, source),
-                    file_path=file_path,
-                )
-            )
+        # child_by_field_name("value") acessa o campo `value:` do variable_declarator
+        value = declarator.child_by_field_name("value")
+        if value and value.type in ("arrow_function", "function_expression", "function"):
+            artifacts.append(_make_artifact(name, "function", node, source, language, file_path))
 
 
 def _js_import_name(node: Node, source: bytes) -> str:
-    """Extrai o nome representativo de um import JavaScript/TypeScript.
+    """Extrai o caminho do módulo de um import JavaScript/TypeScript.
 
     Args:
         node: Nó import_statement.
@@ -576,24 +491,29 @@ def _js_import_name(node: Node, source: bytes) -> str:
     Returns:
         Caminho do módulo importado (ex: "react", "./utils").
     """
-    # Procura string literal com o caminho do módulo
+    # child_by_field_name("source") acessa o campo `source:` do import_statement
+    source_node = node.child_by_field_name("source")
+    if source_node and source_node.text:
+        return source_node.text.decode("utf-8", errors="replace").strip("'\"")
+    # Fallback: procura string literal
     for child in node.children:
-        if child.type == "string":
-            text = child.text.decode("utf-8", errors="replace") if child.text else ""
-            return text.strip("'\"")
-    return _node_text(node, source).strip()
+        if child.type == "string" and child.text:
+            return child.text.decode("utf-8", errors="replace").strip("'\"")
+    return _text(node, source).strip()
 
 
-# ---- TypeScript ------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Extrator TypeScript
+# ---------------------------------------------------------------------------
 
-def _extract_typescript(node: Node, source: bytes, file_path: str) -> list[Artifact]:
-    """Extrai artefatos de um arquivo TypeScript.
+def _extract_typescript(root: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo TypeScript usando field names da gramática.
 
-    Reutiliza o walker JavaScript com linguagem "typescript".
-    Adiciona suporte a interface_declaration e type_alias_declaration.
+    Estende o extrator JavaScript com suporte a:
+    - interface_declaration → "class" (interfaces mapeiam para "class" no modelo)
 
     Args:
-        node: Nó raiz da AST.
+        root: Nó raiz da AST (program).
         source: Bytes do arquivo fonte.
         file_path: Caminho do arquivo.
 
@@ -601,7 +521,7 @@ def _extract_typescript(node: Node, source: bytes, file_path: str) -> list[Artif
         Lista de Artifact extraídos.
     """
     artifacts: list[Artifact] = []
-    _walk_ts(node, source, file_path, artifacts, inside_class=False)
+    _walk_ts(root, source, file_path, artifacts, inside_class=False)
     return artifacts
 
 
@@ -612,103 +532,37 @@ def _walk_ts(
     artifacts: list[Artifact],
     inside_class: bool,
 ) -> None:
-    """Percorre recursivamente a AST TypeScript.
-
-    Estende o walker JS com suporte a interface_declaration.
-    Para os demais tipos de nó, delega ao walker JS.
-
-    Args:
-        node: Nó atual.
-        source: Bytes do arquivo fonte.
-        file_path: Caminho do arquivo.
-        artifacts: Lista acumuladora.
-        inside_class: True se dentro de uma classe.
-    """
     for child in node.children:
         if child.type == "interface_declaration":
-            name = _child_text(child, "type_identifier", "identifier")
+            # child_by_field_name("name") acessa o campo `name:` da gramática TS
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="class",  # interfaces mapeiam para "class" no modelo
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language="typescript",
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
-            # Percorre o corpo da interface para métodos
-            body = next(
-                (c for c in child.children if c.type == "object_type"), None
-            )
+                artifacts.append(_make_artifact(name, "class", child, source, "typescript", file_path))
+            body = child.child_by_field_name("body")
             if body:
                 _walk_ts(body, source, file_path, artifacts, inside_class=True)
 
         elif child.type == "class_declaration":
-            name = _child_text(child, "type_identifier", "identifier")
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="class",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language="typescript",
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
-            body = next(
-                (c for c in child.children if c.type == "class_body"), None
-            )
+                artifacts.append(_make_artifact(name, "class", child, source, "typescript", file_path))
+            body = child.child_by_field_name("body")
             if body:
                 _walk_ts(body, source, file_path, artifacts, inside_class=True)
 
         elif child.type == "method_definition" and inside_class:
-            name = _child_text(child, "property_identifier", "identifier")
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="method",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language="typescript",
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
+                artifacts.append(_make_artifact(name, "method", child, source, "typescript", file_path))
 
         elif child.type == "function_declaration":
-            name = _child_text(child, "identifier")
+            name = _field_text(child, "name")
             if name:
-                artifacts.append(
-                    Artifact(
-                        name=name,
-                        type="function",
-                        start_line=child.start_point.row + 1,
-                        end_line=child.end_point.row + 1,
-                        language="typescript",
-                        content=_node_text(child, source),
-                        file_path=file_path,
-                    )
-                )
+                artifacts.append(_make_artifact(name, "function", child, source, "typescript", file_path))
 
         elif child.type == "import_statement":
             name = _js_import_name(child, source)
-            artifacts.append(
-                Artifact(
-                    name=name,
-                    type="import",
-                    start_line=child.start_point.row + 1,
-                    end_line=child.end_point.row + 1,
-                    language="typescript",
-                    content=_node_text(child, source),
-                    file_path=file_path,
-                )
-            )
+            artifacts.append(_make_artifact(name, "import", child, source, "typescript", file_path))
 
         elif child.type in ("lexical_declaration", "variable_declaration"):
             _extract_js_variable_fn(child, source, file_path, artifacts, "typescript")
@@ -721,14 +575,12 @@ def _walk_ts(
 # Mapeamento de linguagem → extrator
 # ---------------------------------------------------------------------------
 
-_EXTRACTORS: dict[str, _ExtractorFn] = {
+_EXTRACTORS = {
     "python": _extract_python,
     "java": _extract_java,
     "javascript": _extract_javascript,
     "typescript": _extract_typescript,
 }
-
-# _walk_js_single foi removido — TypeScript tem walker próprio (_walk_ts)
 
 
 # ---------------------------------------------------------------------------
@@ -741,6 +593,14 @@ class TreeSitterAnalyzer:
     Suporta Python, Java, JavaScript e TypeScript. Retorna artefatos parciais
     em caso de erros de sintaxe, registrando warnings com a localização.
 
+    A extração usa child_by_field_name() — a API declarativa do Tree-sitter
+    que acessa campos nomeados na gramática, tornando o código conciso e
+    resiliente a mudanças de gramática.
+
+    Thread-safety: não é thread-safe por padrão devido ao cache _PARSERS
+    compartilhado. Para uso concorrente, instancie um TreeSitterAnalyzer
+    por thread.
+
     Args:
         language_map: Mapeamento de extensão → linguagem.
             Usa SUPPORTED_LANGUAGES por padrão.
@@ -752,9 +612,7 @@ class TreeSitterAnalyzer:
         ...     print(a.type, a.name, a.start_line)
     """
 
-    def __init__(
-        self, language_map: dict[str, str] | None = None
-    ) -> None:
+    def __init__(self, language_map: dict[str, str] | None = None) -> None:
         self._language_map = language_map or SUPPORTED_LANGUAGES
 
     def analyze(self, file_path: Path) -> list[Artifact]:
@@ -783,10 +641,8 @@ class TreeSitterAnalyzer:
 
         source = self._read_source(file_path)
         parser = _get_parser(language)
-
         tree = parser.parse(source)
 
-        # Detecta erros de sintaxe na AST
         if tree.root_node.has_error:
             logger.warning(
                 "Erros de sintaxe detectados em '%s'. "
@@ -819,8 +675,7 @@ class TreeSitterAnalyzer:
         all_artifacts: list[Artifact] = []
         for path in file_paths:
             try:
-                artifacts = self.analyze(path)
-                all_artifacts.extend(artifacts)
+                all_artifacts.extend(self.analyze(path))
             except (UnsupportedLanguageError, FileNotFoundError) as exc:
                 logger.warning("Ignorando arquivo '%s': %s", path, exc)
             except Exception as exc:  # noqa: BLE001

--- a/src/tokemize/core/parser/tree_sitter_analyzer.py
+++ b/src/tokemize/core/parser/tree_sitter_analyzer.py
@@ -1,0 +1,883 @@
+"""Analisador sintático baseado em Tree-sitter para o Tokemize.
+
+Extrai artefatos estruturais (classes, funções, métodos, imports) de arquivos
+de código-fonte usando grammars Tree-sitter para Python, Java, JavaScript e
+TypeScript.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Callable
+
+import tree_sitter_java as tsjava
+import tree_sitter_javascript as tsjs
+import tree_sitter_python as tspython
+import tree_sitter_typescript as tsts
+from tree_sitter import Language, Node, Parser
+
+from tokemize.models.artifact import Artifact
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Linguagens suportadas
+# ---------------------------------------------------------------------------
+
+SUPPORTED_LANGUAGES: dict[str, str] = {
+    ".py": "python",
+    ".java": "java",
+    ".js": "javascript",
+    ".ts": "typescript",
+}
+
+
+class UnsupportedLanguageError(ValueError):
+    """Lançada quando a extensão do arquivo não tem grammar Tree-sitter mapeado.
+
+    Args:
+        extension: Extensão do arquivo não suportada.
+    """
+
+    def __init__(self, extension: str) -> None:
+        super().__init__(
+            f"Extensão '{extension}' não é suportada. "
+            f"Extensões suportadas: {sorted(SUPPORTED_LANGUAGES.keys())}"
+        )
+        self.extension = extension
+
+
+class ParseError(RuntimeError):
+    """Lançada quando o Tree-sitter falha ao processar o arquivo.
+
+    Args:
+        file_path: Caminho do arquivo que causou o erro.
+        message: Descrição do erro.
+    """
+
+    def __init__(self, file_path: Path, message: str) -> None:
+        super().__init__(f"Erro ao analisar '{file_path}': {message}")
+        self.file_path = file_path
+
+
+# ---------------------------------------------------------------------------
+# Inicialização lazy dos parsers (um por linguagem)
+# ---------------------------------------------------------------------------
+
+_PARSERS: dict[str, Parser] = {}
+
+
+def _get_parser(language: str) -> Parser:
+    """Retorna (ou cria) o parser Tree-sitter para a linguagem.
+
+    Args:
+        language: Nome da linguagem ("python", "java", "javascript", "typescript").
+
+    Returns:
+        Instância de Parser configurada para a linguagem.
+
+    Raises:
+        UnsupportedLanguageError: Se a linguagem não for suportada.
+    """
+    if language in _PARSERS:
+        return _PARSERS[language]
+
+    lang_obj: Language
+    if language == "python":
+        lang_obj = Language(tspython.language())
+    elif language == "java":
+        lang_obj = Language(tsjava.language())
+    elif language == "javascript":
+        lang_obj = Language(tsjs.language())
+    elif language == "typescript":
+        lang_obj = Language(tsts.language_typescript())
+    else:
+        raise UnsupportedLanguageError(language)
+
+    parser = Parser(lang_obj)
+    _PARSERS[language] = parser
+    return parser
+
+
+# ---------------------------------------------------------------------------
+# Extratores por linguagem
+# ---------------------------------------------------------------------------
+
+# Tipo de função extratora: recebe (node, source_bytes, file_path) → list[Artifact]
+_ExtractorFn = Callable[[Node, bytes, str], list[Artifact]]
+
+
+def _node_text(node: Node, source: bytes) -> str:
+    """Extrai o texto original de um nó da AST.
+
+    Args:
+        node: Nó da AST.
+        source: Bytes do arquivo fonte.
+
+    Returns:
+        Texto do nó como string UTF-8.
+    """
+    return source[node.start_byte:node.end_byte].decode("utf-8", errors="replace")
+
+
+def _child_text(node: Node, *types: str) -> str:
+    """Retorna o texto do primeiro filho com um dos tipos especificados.
+
+    Args:
+        node: Nó pai.
+        *types: Tipos de nó a procurar.
+
+    Returns:
+        Texto do filho encontrado ou string vazia.
+    """
+    for child in node.children:
+        if child.type in types:
+            return child.text.decode("utf-8", errors="replace") if child.text else ""
+    return ""
+
+
+# ---- Python ----------------------------------------------------------------
+
+def _extract_python(node: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo Python.
+
+    Percorre a AST recursivamente extraindo:
+    - import_statement → type "import"
+    - import_from_statement → type "import"
+    - function_definition (top-level) → type "function"
+    - class_definition → type "class"
+    - function_definition dentro de class → type "method"
+    - decorated_definition → delega ao nó interno
+
+    Args:
+        node: Nó raiz da AST.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo (para metadados).
+
+    Returns:
+        Lista de Artifact extraídos.
+    """
+    artifacts: list[Artifact] = []
+    _walk_python(node, source, file_path, artifacts, inside_class=False)
+    return artifacts
+
+
+def _walk_python(
+    node: Node,
+    source: bytes,
+    file_path: str,
+    artifacts: list[Artifact],
+    inside_class: bool,
+) -> None:
+    """Percorre recursivamente a AST Python extraindo artefatos.
+
+    Args:
+        node: Nó atual da AST.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+        artifacts: Lista acumuladora de artefatos.
+        inside_class: True se o nó atual está dentro de uma classe.
+    """
+    for child in node.children:
+        if child.type in ("import_statement", "import_from_statement"):
+            name = _python_import_name(child, source)
+            artifacts.append(
+                Artifact(
+                    name=name,
+                    type="import",
+                    start_line=child.start_point.row + 1,
+                    end_line=child.end_point.row + 1,
+                    language="python",
+                    content=_node_text(child, source),
+                    file_path=file_path,
+                )
+            )
+
+        elif child.type == "decorated_definition":
+            # Delega ao nó interno (function_definition ou class_definition)
+            # O range do decorated_definition inclui os decorators
+            inner = next(
+                (
+                    c
+                    for c in child.children
+                    if c.type in ("function_definition", "class_definition")
+                ),
+                None,
+            )
+            if inner:
+                _extract_python_def(
+                    inner, child, source, file_path, artifacts, inside_class
+                )
+
+        elif child.type in ("function_definition", "class_definition"):
+            _extract_python_def(
+                child, child, source, file_path, artifacts, inside_class
+            )
+
+
+def _extract_python_def(
+    node: Node,
+    range_node: Node,
+    source: bytes,
+    file_path: str,
+    artifacts: list[Artifact],
+    inside_class: bool,
+) -> None:
+    """Extrai um artefato de definição Python (função ou classe).
+
+    Args:
+        node: Nó da definição (function_definition ou class_definition).
+        range_node: Nó usado para calcular start/end line (pode incluir decorators).
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+        artifacts: Lista acumuladora.
+        inside_class: True se está dentro de uma classe.
+    """
+    name = _child_text(node, "identifier")
+    if not name:
+        return
+
+    if node.type == "function_definition":
+        artifact_type = "method" if inside_class else "function"
+        artifacts.append(
+            Artifact(
+                name=name,
+                type=artifact_type,
+                start_line=range_node.start_point.row + 1,
+                end_line=range_node.end_point.row + 1,
+                language="python",
+                content=_node_text(range_node, source),
+                file_path=file_path,
+            )
+        )
+
+    elif node.type == "class_definition":
+        artifacts.append(
+            Artifact(
+                name=name,
+                type="class",
+                start_line=range_node.start_point.row + 1,
+                end_line=range_node.end_point.row + 1,
+                language="python",
+                content=_node_text(range_node, source),
+                file_path=file_path,
+            )
+        )
+        # Percorre o corpo da classe para extrair métodos
+        body = next(
+            (c for c in node.children if c.type == "block"), None
+        )
+        if body:
+            _walk_python(body, source, file_path, artifacts, inside_class=True)
+
+
+def _python_import_name(node: Node, source: bytes) -> str:
+    """Extrai o nome representativo de um import Python.
+
+    Para `import os` → "os"
+    Para `from pathlib import Path` → "pathlib.Path"
+
+    Args:
+        node: Nó import_statement ou import_from_statement.
+        source: Bytes do arquivo fonte.
+
+    Returns:
+        Nome do import como string.
+    """
+    if node.type == "import_statement":
+        # import X, Y → pega o primeiro nome
+        for child in node.children:
+            if child.type in ("dotted_name", "aliased_import"):
+                return child.text.decode("utf-8", errors="replace") if child.text else ""
+        return _node_text(node, source).strip()
+
+    # import_from_statement: from X import Y
+    module = ""
+    imported = ""
+    for child in node.children:
+        if child.type == "dotted_name" and not module:
+            module = child.text.decode("utf-8", errors="replace") if child.text else ""
+        elif child.type in ("dotted_name", "identifier") and module:
+            imported = child.text.decode("utf-8", errors="replace") if child.text else ""
+            break
+        elif child.type == "import":
+            continue
+    if module and imported:
+        return f"{module}.{imported}"
+    return module or _node_text(node, source).strip()
+
+
+# ---- Java ------------------------------------------------------------------
+
+def _extract_java(node: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo Java.
+
+    Extrai:
+    - import_declaration → type "import"
+    - class_declaration / interface_declaration → type "class"
+    - method_declaration / constructor_declaration → type "method"
+
+    Args:
+        node: Nó raiz da AST.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+
+    Returns:
+        Lista de Artifact extraídos.
+    """
+    artifacts: list[Artifact] = []
+    _walk_java(node, source, file_path, artifacts, inside_class=False)
+    return artifacts
+
+
+def _walk_java(
+    node: Node,
+    source: bytes,
+    file_path: str,
+    artifacts: list[Artifact],
+    inside_class: bool,
+) -> None:
+    """Percorre recursivamente a AST Java.
+
+    Args:
+        node: Nó atual.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+        artifacts: Lista acumuladora.
+        inside_class: True se dentro de uma classe.
+    """
+    for child in node.children:
+        if child.type == "import_declaration":
+            # Pega o scoped_identifier ou dotted_name
+            name = ""
+            for c in child.children:
+                if c.type in ("scoped_identifier", "identifier"):
+                    name = c.text.decode("utf-8", errors="replace") if c.text else ""
+                    break
+            artifacts.append(
+                Artifact(
+                    name=name or _node_text(child, source).strip(),
+                    type="import",
+                    start_line=child.start_point.row + 1,
+                    end_line=child.end_point.row + 1,
+                    language="java",
+                    content=_node_text(child, source),
+                    file_path=file_path,
+                )
+            )
+
+        elif child.type in ("class_declaration", "interface_declaration", "enum_declaration"):
+            name = _child_text(child, "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="class",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language="java",
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+            # Percorre o corpo para métodos
+            _walk_java(child, source, file_path, artifacts, inside_class=True)
+
+        elif child.type in ("method_declaration", "constructor_declaration") and inside_class:
+            name = _child_text(child, "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="method",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language="java",
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+
+        else:
+            _walk_java(child, source, file_path, artifacts, inside_class)
+
+
+# ---- JavaScript ------------------------------------------------------------
+
+def _extract_javascript(node: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo JavaScript.
+
+    Extrai:
+    - import_statement → type "import"
+    - class_declaration → type "class"
+    - method_definition → type "method"
+    - function_declaration → type "function"
+    - lexical_declaration / variable_declaration com arrow function → type "function"
+
+    Args:
+        node: Nó raiz da AST.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+
+    Returns:
+        Lista de Artifact extraídos.
+    """
+    artifacts: list[Artifact] = []
+    _walk_js(node, source, file_path, artifacts, language="javascript", inside_class=False)
+    return artifacts
+
+
+def _walk_js(
+    node: Node,
+    source: bytes,
+    file_path: str,
+    artifacts: list[Artifact],
+    language: str,
+    inside_class: bool,
+) -> None:
+    """Percorre recursivamente a AST JavaScript/TypeScript.
+
+    Args:
+        node: Nó atual.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+        artifacts: Lista acumuladora.
+        language: "javascript" ou "typescript".
+        inside_class: True se dentro de uma classe.
+    """
+    for child in node.children:
+        if child.type == "import_statement":
+            name = _js_import_name(child, source)
+            artifacts.append(
+                Artifact(
+                    name=name,
+                    type="import",
+                    start_line=child.start_point.row + 1,
+                    end_line=child.end_point.row + 1,
+                    language=language,
+                    content=_node_text(child, source),
+                    file_path=file_path,
+                )
+            )
+
+        elif child.type == "class_declaration":
+            # JS usa "identifier", TS usa "type_identifier"
+            name = _child_text(child, "identifier", "type_identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="class",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language=language,
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+            # Percorre o corpo da classe
+            body = next(
+                (c for c in child.children if c.type == "class_body"), None
+            )
+            if body:
+                _walk_js(body, source, file_path, artifacts, language, inside_class=True)
+
+        elif child.type == "method_definition" and inside_class:
+            name = _child_text(child, "property_identifier", "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="method",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language=language,
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+
+        elif child.type == "function_declaration":
+            name = _child_text(child, "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="function",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language=language,
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+
+        elif child.type in ("lexical_declaration", "variable_declaration"):
+            # Detecta: const foo = () => ... ou const foo = function() ...
+            _extract_js_variable_fn(child, source, file_path, artifacts, language)
+
+        else:
+            _walk_js(child, source, file_path, artifacts, language, inside_class)
+
+
+def _extract_js_variable_fn(
+    node: Node,
+    source: bytes,
+    file_path: str,
+    artifacts: list[Artifact],
+    language: str,
+) -> None:
+    """Extrai funções declaradas como variáveis (arrow functions, function expressions).
+
+    Args:
+        node: Nó lexical_declaration ou variable_declaration.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+        artifacts: Lista acumuladora.
+        language: "javascript" ou "typescript".
+    """
+    for declarator in node.children:
+        if declarator.type != "variable_declarator":
+            continue
+        name = _child_text(declarator, "identifier")
+        if not name:
+            continue
+        # Verifica se o valor é arrow_function ou function_expression
+        value = next(
+            (
+                c
+                for c in declarator.children
+                if c.type in ("arrow_function", "function_expression", "function")
+            ),
+            None,
+        )
+        if value:
+            artifacts.append(
+                Artifact(
+                    name=name,
+                    type="function",
+                    start_line=node.start_point.row + 1,
+                    end_line=node.end_point.row + 1,
+                    language=language,
+                    content=_node_text(node, source),
+                    file_path=file_path,
+                )
+            )
+
+
+def _js_import_name(node: Node, source: bytes) -> str:
+    """Extrai o nome representativo de um import JavaScript/TypeScript.
+
+    Args:
+        node: Nó import_statement.
+        source: Bytes do arquivo fonte.
+
+    Returns:
+        Caminho do módulo importado (ex: "react", "./utils").
+    """
+    # Procura string literal com o caminho do módulo
+    for child in node.children:
+        if child.type == "string":
+            text = child.text.decode("utf-8", errors="replace") if child.text else ""
+            return text.strip("'\"")
+    return _node_text(node, source).strip()
+
+
+# ---- TypeScript ------------------------------------------------------------
+
+def _extract_typescript(node: Node, source: bytes, file_path: str) -> list[Artifact]:
+    """Extrai artefatos de um arquivo TypeScript.
+
+    Reutiliza o walker JavaScript com linguagem "typescript".
+    Adiciona suporte a interface_declaration e type_alias_declaration.
+
+    Args:
+        node: Nó raiz da AST.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+
+    Returns:
+        Lista de Artifact extraídos.
+    """
+    artifacts: list[Artifact] = []
+    _walk_ts(node, source, file_path, artifacts, inside_class=False)
+    return artifacts
+
+
+def _walk_ts(
+    node: Node,
+    source: bytes,
+    file_path: str,
+    artifacts: list[Artifact],
+    inside_class: bool,
+) -> None:
+    """Percorre recursivamente a AST TypeScript.
+
+    Estende o walker JS com suporte a interface_declaration.
+    Para os demais tipos de nó, delega ao walker JS.
+
+    Args:
+        node: Nó atual.
+        source: Bytes do arquivo fonte.
+        file_path: Caminho do arquivo.
+        artifacts: Lista acumuladora.
+        inside_class: True se dentro de uma classe.
+    """
+    for child in node.children:
+        if child.type == "interface_declaration":
+            name = _child_text(child, "type_identifier", "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="class",  # interfaces mapeiam para "class" no modelo
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language="typescript",
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+            # Percorre o corpo da interface para métodos
+            body = next(
+                (c for c in child.children if c.type == "object_type"), None
+            )
+            if body:
+                _walk_ts(body, source, file_path, artifacts, inside_class=True)
+
+        elif child.type == "class_declaration":
+            name = _child_text(child, "type_identifier", "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="class",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language="typescript",
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+            body = next(
+                (c for c in child.children if c.type == "class_body"), None
+            )
+            if body:
+                _walk_ts(body, source, file_path, artifacts, inside_class=True)
+
+        elif child.type == "method_definition" and inside_class:
+            name = _child_text(child, "property_identifier", "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="method",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language="typescript",
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+
+        elif child.type == "function_declaration":
+            name = _child_text(child, "identifier")
+            if name:
+                artifacts.append(
+                    Artifact(
+                        name=name,
+                        type="function",
+                        start_line=child.start_point.row + 1,
+                        end_line=child.end_point.row + 1,
+                        language="typescript",
+                        content=_node_text(child, source),
+                        file_path=file_path,
+                    )
+                )
+
+        elif child.type == "import_statement":
+            name = _js_import_name(child, source)
+            artifacts.append(
+                Artifact(
+                    name=name,
+                    type="import",
+                    start_line=child.start_point.row + 1,
+                    end_line=child.end_point.row + 1,
+                    language="typescript",
+                    content=_node_text(child, source),
+                    file_path=file_path,
+                )
+            )
+
+        elif child.type in ("lexical_declaration", "variable_declaration"):
+            _extract_js_variable_fn(child, source, file_path, artifacts, "typescript")
+
+        else:
+            _walk_ts(child, source, file_path, artifacts, inside_class)
+
+
+# ---------------------------------------------------------------------------
+# Mapeamento de linguagem → extrator
+# ---------------------------------------------------------------------------
+
+_EXTRACTORS: dict[str, _ExtractorFn] = {
+    "python": _extract_python,
+    "java": _extract_java,
+    "javascript": _extract_javascript,
+    "typescript": _extract_typescript,
+}
+
+# _walk_js_single foi removido — TypeScript tem walker próprio (_walk_ts)
+
+
+# ---------------------------------------------------------------------------
+# Classe principal
+# ---------------------------------------------------------------------------
+
+class TreeSitterAnalyzer:
+    """Analisa arquivos de código-fonte com Tree-sitter e extrai artefatos.
+
+    Suporta Python, Java, JavaScript e TypeScript. Retorna artefatos parciais
+    em caso de erros de sintaxe, registrando warnings com a localização.
+
+    Args:
+        language_map: Mapeamento de extensão → linguagem.
+            Usa SUPPORTED_LANGUAGES por padrão.
+
+    Example:
+        >>> analyzer = TreeSitterAnalyzer()
+        >>> artifacts = analyzer.analyze(Path("meu_arquivo.py"))
+        >>> for a in artifacts:
+        ...     print(a.type, a.name, a.start_line)
+    """
+
+    def __init__(
+        self, language_map: dict[str, str] | None = None
+    ) -> None:
+        self._language_map = language_map or SUPPORTED_LANGUAGES
+
+    def analyze(self, file_path: Path) -> list[Artifact]:
+        """Extrai artefatos sintáticos de um arquivo de código-fonte.
+
+        Args:
+            file_path: Caminho para o arquivo a ser analisado.
+
+        Returns:
+            Lista de Artifact extraídos. Pode ser parcial se houver erros
+            de sintaxe — os artefatos válidos são retornados mesmo assim.
+
+        Raises:
+            UnsupportedLanguageError: Se a extensão não for suportada.
+            FileNotFoundError: Se o arquivo não existir.
+        """
+        file_path = Path(file_path)
+
+        if not file_path.exists():
+            raise FileNotFoundError(f"Arquivo não encontrado: {file_path}")
+
+        ext = file_path.suffix.lower()
+        language = self._language_map.get(ext)
+        if language is None:
+            raise UnsupportedLanguageError(ext)
+
+        source = self._read_source(file_path)
+        parser = _get_parser(language)
+
+        tree = parser.parse(source)
+
+        # Detecta erros de sintaxe na AST
+        if tree.root_node.has_error:
+            logger.warning(
+                "Erros de sintaxe detectados em '%s'. "
+                "Artefatos válidos serão retornados parcialmente.",
+                file_path,
+            )
+            self._log_syntax_errors(tree.root_node, file_path)
+
+        extractor = _EXTRACTORS[language]
+        artifacts = extractor(tree.root_node, source, str(file_path))
+
+        logger.debug(
+            "Arquivo '%s' analisado: %d artefatos extraídos",
+            file_path,
+            len(artifacts),
+        )
+        return artifacts
+
+    def analyze_many(self, file_paths: list[Path]) -> list[Artifact]:
+        """Extrai artefatos de múltiplos arquivos.
+
+        Arquivos que falham são logados e ignorados (não interrompem o processo).
+
+        Args:
+            file_paths: Lista de caminhos de arquivos a serem analisados.
+
+        Returns:
+            Lista concatenada de todos os artefatos extraídos.
+        """
+        all_artifacts: list[Artifact] = []
+        for path in file_paths:
+            try:
+                artifacts = self.analyze(path)
+                all_artifacts.extend(artifacts)
+            except (UnsupportedLanguageError, FileNotFoundError) as exc:
+                logger.warning("Ignorando arquivo '%s': %s", path, exc)
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Erro inesperado ao analisar '%s': %s", path, exc, exc_info=True
+                )
+        return all_artifacts
+
+    def detect_language(self, file_path: Path) -> str:
+        """Detecta a linguagem de um arquivo pela extensão.
+
+        Args:
+            file_path: Caminho do arquivo.
+
+        Returns:
+            Nome da linguagem (ex: "python").
+
+        Raises:
+            UnsupportedLanguageError: Se a extensão não for suportada.
+        """
+        ext = Path(file_path).suffix.lower()
+        language = self._language_map.get(ext)
+        if language is None:
+            raise UnsupportedLanguageError(ext)
+        return language
+
+    def _read_source(self, file_path: Path) -> bytes:
+        """Lê o conteúdo de um arquivo como bytes.
+
+        Args:
+            file_path: Caminho do arquivo.
+
+        Returns:
+            Conteúdo do arquivo em bytes.
+
+        Raises:
+            ParseError: Se o arquivo não puder ser lido.
+        """
+        try:
+            return file_path.read_bytes()
+        except (OSError, PermissionError) as exc:
+            raise ParseError(file_path, str(exc)) from exc
+
+    def _log_syntax_errors(self, node: Node, file_path: Path) -> None:
+        """Percorre a AST e loga os nós com erro de sintaxe.
+
+        Args:
+            node: Nó raiz da AST.
+            file_path: Caminho do arquivo (para contexto no log).
+        """
+        if node.type == "ERROR" or node.is_missing:
+            logger.warning(
+                "Erro de sintaxe em '%s' na linha %d, coluna %d",
+                file_path,
+                node.start_point.row + 1,
+                node.start_point.column + 1,
+            )
+        for child in node.children:
+            if child.has_error:
+                self._log_syntax_errors(child, file_path)

--- a/src/tokemize/models/__init__.py
+++ b/src/tokemize/models/__init__.py
@@ -1,0 +1,1 @@
+# models package

--- a/src/tokemize/models/artifact.py
+++ b/src/tokemize/models/artifact.py
@@ -1,0 +1,43 @@
+"""Modelo de dados para artefatos extraídos do código-fonte."""
+
+from dataclasses import dataclass
+
+
+@dataclass
+class Artifact:
+    """Unidade estrutural extraída do código-fonte pelo Parser.
+
+    Attributes:
+        name: Nome do artefato (ex: nome da função ou classe).
+        type: Tipo do artefato: "function", "class", "method", "import".
+        start_line: Número da linha inicial (1-indexed).
+        end_line: Número da linha final (1-indexed).
+        language: Linguagem de programação (ex: "python", "java").
+        content: Conteúdo textual original do artefato, sem modificações.
+        file_path: Caminho do arquivo de origem.
+    """
+
+    name: str
+    type: str
+    start_line: int
+    end_line: int
+    language: str
+    content: str
+    file_path: str = ""
+
+    def __post_init__(self) -> None:
+        """Valida invariantes do artefato.
+
+        Raises:
+            ValueError: Se start_line > end_line ou tipo inválido.
+        """
+        if self.start_line > self.end_line:
+            raise ValueError(
+                f"start_line ({self.start_line}) não pode ser maior que "
+                f"end_line ({self.end_line})"
+            )
+        valid_types = {"function", "class", "method", "import"}
+        if self.type not in valid_types:
+            raise ValueError(
+                f"Tipo inválido '{self.type}'. Tipos válidos: {valid_types}"
+            )

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# tests package

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -2,20 +2,25 @@
 
 Cobre:
 - Varredura básica de diretório
-- Aplicação de lista de ignores
-- Coleta de metadados (linguagem, extensão, tamanho, linhas)
+- Aplicação de lista de ignores (parametrizado)
+- Coleta de metadados (linguagem, extensão, tamanho, linhas) (parametrizado)
 - Arquivos com extensão não suportada são ignorados
 - Diretórios ignorados por padrão (.git, node_modules, etc.)
 - Diretórios ignorados customizados
 - Arquivo maior que o limite é ignorado
 - Diretório inválido levanta NotADirectoryError
+- Proteção contra symlinks
+- PermissionError tratado sem quebrar a varredura
+- iter_files() lazy/streaming
 - Propriedades do scanner (ignore_dirs, supported_extensions)
 """
 
 from __future__ import annotations
 
 import os
+import sys
 from pathlib import Path
+from unittest.mock import patch
 
 import pytest
 
@@ -60,34 +65,18 @@ def repo(tmp_path: Path) -> Path:
     root = tmp_path / "repo"
     root.mkdir()
 
-    # Arquivos válidos
     (root / "main.py").write_text("def main(): pass\n")
     (root / "utils.py").write_text("import os\n\ndef helper(): pass\n")
     (root / "App.java").write_text("public class App {}\n")
     (root / "index.js").write_text("function init() {}\n")
     (root / "types.ts").write_text("interface IFoo { bar(): void; }\n")
-
-    # Arquivo com extensão não suportada
     (root / "README.md").write_text("# Readme\n")
 
-    # Diretórios ignorados
-    git_dir = root / ".git"
-    git_dir.mkdir()
-    (git_dir / "config").write_text("[core]\n")
+    for ignored_dir in (".git", "node_modules", "dist", "build"):
+        d = root / ignored_dir
+        d.mkdir()
+        (d / "file.js").write_text("// ignored\n")
 
-    nm_dir = root / "node_modules"
-    nm_dir.mkdir()
-    (nm_dir / "lib.js").write_text("module.exports = {};\n")
-
-    dist_dir = root / "dist"
-    dist_dir.mkdir()
-    (dist_dir / "bundle.js").write_text("(function(){})()\n")
-
-    build_dir = root / "build"
-    build_dir.mkdir()
-    (build_dir / "output.py").write_text("x = 1\n")
-
-    # Subdiretório válido
     src_dir = root / "src"
     src_dir.mkdir()
     (src_dir / "helper.py").write_text("def helper(): return 42\n")
@@ -134,54 +123,37 @@ class TestScanBasic:
     def test_scan_skipped_files_count(self, scanner: RepositoryScanner, repo: Path) -> None:
         """skipped_files deve contar arquivos com extensão não suportada."""
         result = scanner.scan(repo)
-        # README.md é ignorado por extensão
         assert result.skipped_files >= 1
 
     def test_scan_invalid_directory_raises(self, scanner: RepositoryScanner, tmp_path: Path) -> None:
         """scan() deve levantar NotADirectoryError para caminho inválido."""
-        fake_path = tmp_path / "nao_existe"
         with pytest.raises(NotADirectoryError, match="nao_existe"):
-            scanner.scan(fake_path)
+            scanner.scan(tmp_path / "nao_existe")
 
     def test_scan_file_path_raises(self, scanner: RepositoryScanner, tmp_path: Path) -> None:
         """scan() deve levantar NotADirectoryError se o caminho for um arquivo."""
-        file_path = tmp_path / "arquivo.py"
-        file_path.write_text("x = 1")
+        f = tmp_path / "arquivo.py"
+        f.write_text("x = 1")
         with pytest.raises(NotADirectoryError):
-            scanner.scan(file_path)
+            scanner.scan(f)
 
 
 # ---------------------------------------------------------------------------
-# Testes de diretórios ignorados
+# Testes de diretórios ignorados — parametrizado
 # ---------------------------------------------------------------------------
 
 
 class TestIgnoreDirs:
     """Testes de aplicação da lista de diretórios ignorados."""
 
-    def test_git_dir_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivos dentro de .git não devem aparecer no resultado."""
+    @pytest.mark.parametrize("ignored_dir", [".git", "node_modules", "dist", "build"])
+    def test_default_ignored_dirs_are_excluded(
+        self, scanner: RepositoryScanner, repo: Path, ignored_dir: str
+    ) -> None:
+        """Diretórios padrão ignorados não devem aparecer nos resultados."""
         result = scanner.scan(repo)
         paths = [str(f.relative_path) for f in result.files]
-        assert not any(".git" in p for p in paths)
-
-    def test_node_modules_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivos dentro de node_modules não devem aparecer no resultado."""
-        result = scanner.scan(repo)
-        paths = [str(f.relative_path) for f in result.files]
-        assert not any("node_modules" in p for p in paths)
-
-    def test_dist_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivos dentro de dist não devem aparecer no resultado."""
-        result = scanner.scan(repo)
-        paths = [str(f.relative_path) for f in result.files]
-        assert not any("dist" in p for p in paths)
-
-    def test_build_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivos dentro de build não devem aparecer no resultado."""
-        result = scanner.scan(repo)
-        paths = [str(f.relative_path) for f in result.files]
-        assert not any("build" in p for p in paths)
+        assert not any(ignored_dir in p for p in paths)
 
     def test_custom_ignore_dir(self, repo: Path) -> None:
         """Diretório customizado deve ser ignorado quando adicionado à lista."""
@@ -194,10 +166,9 @@ class TestIgnoreDirs:
         paths = [str(f.relative_path) for f in result.files]
         assert not any("meu_cache" in p for p in paths)
 
-    def test_custom_ignore_merges_with_defaults(self, repo: Path) -> None:
+    def test_custom_ignore_merges_with_defaults(self) -> None:
         """Ignorar customizado deve mesclar com DEFAULT_IGNORE_DIRS."""
         scanner = RepositoryScanner(ignore_dirs={"extra_dir"})
-        # .git ainda deve ser ignorado
         assert ".git" in scanner.ignore_dirs
         assert "extra_dir" in scanner.ignore_dirs
 
@@ -212,43 +183,51 @@ class TestIgnoreDirs:
         cache_dir.mkdir()
         (cache_dir / "main.cpython-311.pyc").write_bytes(b"\x00\x00")
 
-        scanner = RepositoryScanner()
-        result = scanner.scan(repo)
+        result = RepositoryScanner().scan(repo)
         paths = [str(f.relative_path) for f in result.files]
         assert not any("__pycache__" in p for p in paths)
 
+    def test_egg_info_wildcard_is_ignored(self, repo: Path) -> None:
+        """Diretórios com padrão *.egg-info devem ser ignorados."""
+        egg_dir = repo / "mypackage.egg-info"
+        egg_dir.mkdir()
+        (egg_dir / "PKG-INFO").write_text("Name: mypackage\n")
+        (egg_dir / "setup.py").write_text("# setup\n")
+
+        result = RepositoryScanner().scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any("egg-info" in p for p in paths)
+
 
 # ---------------------------------------------------------------------------
-# Testes de metadados dos arquivos
+# Testes de metadados — parametrizado por linguagem
 # ---------------------------------------------------------------------------
 
 
 class TestFileMetadata:
     """Testes de coleta de metadados dos arquivos."""
 
-    def test_metadata_language_python(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivo .py deve ter linguagem 'python'."""
+    @pytest.mark.parametrize(
+        "extension, expected_language",
+        [
+            (".py", "python"),
+            (".java", "java"),
+            (".js", "javascript"),
+            (".ts", "typescript"),
+        ],
+    )
+    def test_metadata_language_by_extension(
+        self,
+        scanner: RepositoryScanner,
+        repo: Path,
+        extension: str,
+        expected_language: str,
+    ) -> None:
+        """Cada extensão deve mapear para a linguagem correta nos metadados."""
         result = scanner.scan(repo)
-        py_files = [f for f in result.files if f.extension == ".py"]
-        assert all(f.language == "python" for f in py_files)
-
-    def test_metadata_language_java(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivo .java deve ter linguagem 'java'."""
-        result = scanner.scan(repo)
-        java_files = [f for f in result.files if f.extension == ".java"]
-        assert all(f.language == "java" for f in java_files)
-
-    def test_metadata_language_javascript(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivo .js deve ter linguagem 'javascript'."""
-        result = scanner.scan(repo)
-        js_files = [f for f in result.files if f.extension == ".js"]
-        assert all(f.language == "javascript" for f in js_files)
-
-    def test_metadata_language_typescript(self, scanner: RepositoryScanner, repo: Path) -> None:
-        """Arquivo .ts deve ter linguagem 'typescript'."""
-        result = scanner.scan(repo)
-        ts_files = [f for f in result.files if f.extension == ".ts"]
-        assert all(f.language == "typescript" for f in ts_files)
+        files = [f for f in result.files if f.extension == extension]
+        assert len(files) > 0, f"Nenhum arquivo {extension} encontrado"
+        assert all(f.language == expected_language for f in files)
 
     def test_metadata_size_bytes_positive(self, scanner: RepositoryScanner, repo: Path) -> None:
         """size_bytes deve ser maior que zero para arquivos não vazios."""
@@ -264,20 +243,17 @@ class TestFileMetadata:
         """line_count deve refletir o número real de linhas do arquivo."""
         root = tmp_path / "proj"
         root.mkdir()
-        content = "line1\nline2\nline3\n"
-        (root / "test.py").write_text(content)
+        (root / "test.py").write_text("line1\nline2\nline3\n")
 
-        scanner = RepositoryScanner()
-        result = scanner.scan(root)
+        result = RepositoryScanner().scan(root)
         assert len(result.files) == 1
         assert result.files[0].line_count == 3
 
-    def test_metadata_relative_path(self, scanner: RepositoryScanner, repo: Path) -> None:
+    def test_metadata_relative_path_is_not_absolute(self, scanner: RepositoryScanner, repo: Path) -> None:
         """relative_path deve ser relativo à raiz do repositório."""
         result = scanner.scan(repo)
         for f in result.files:
             assert not f.relative_path.is_absolute()
-            assert str(f.relative_path) != str(f.path)
 
     def test_metadata_absolute_path_exists(self, scanner: RepositoryScanner, repo: Path) -> None:
         """path deve ser absoluto e o arquivo deve existir."""
@@ -310,8 +286,7 @@ class TestFileSizeLimit:
         """Arquivo maior que max_file_size_bytes deve ser ignorado."""
         root = tmp_path / "proj"
         root.mkdir()
-        big_file = root / "big.py"
-        big_file.write_bytes(b"x = 1\n" * 200)  # ~1200 bytes
+        (root / "big.py").write_bytes(b"x = 1\n" * 200)
 
         scanner = RepositoryScanner(max_file_size_bytes=100)
         result = scanner.scan(root)
@@ -322,34 +297,30 @@ class TestFileSizeLimit:
         """Arquivo dentro do limite deve ser incluído normalmente."""
         root = tmp_path / "proj"
         root.mkdir()
-        small_file = root / "small.py"
-        small_file.write_text("x = 1\n")
+        (root / "small.py").write_text("x = 1\n")
 
-        scanner = RepositoryScanner(max_file_size_bytes=1024)
-        result = scanner.scan(root)
+        result = RepositoryScanner(max_file_size_bytes=1024).scan(root)
         assert result.total_files == 1
 
 
 # ---------------------------------------------------------------------------
-# Testes de extensões suportadas
+# Testes de extensões suportadas — parametrizado
 # ---------------------------------------------------------------------------
 
 
 class TestSupportedExtensions:
     """Testes de filtragem por extensão."""
 
-    def test_unsupported_extension_is_skipped(self, tmp_path: Path) -> None:
+    @pytest.mark.parametrize("unsupported_file", ["notes.txt", "data.json", "style.css"])
+    def test_unsupported_extension_is_skipped(self, tmp_path: Path, unsupported_file: str) -> None:
         """Arquivos com extensão não suportada devem ser ignorados."""
         root = tmp_path / "proj"
         root.mkdir()
-        (root / "notes.txt").write_text("hello\n")
-        (root / "data.json").write_text("{}\n")
-        (root / "style.css").write_text("body {}\n")
+        (root / unsupported_file).write_text("content\n")
 
-        scanner = RepositoryScanner()
-        result = scanner.scan(root)
+        result = RepositoryScanner().scan(root)
         assert result.total_files == 0
-        assert result.skipped_files == 3
+        assert result.skipped_files == 1
 
     def test_custom_supported_extensions(self, tmp_path: Path) -> None:
         """Scanner com extensões customizadas deve respeitar a lista fornecida."""
@@ -358,8 +329,7 @@ class TestSupportedExtensions:
         (root / "script.rb").write_text("puts 'hello'\n")
         (root / "main.py").write_text("print('hi')\n")
 
-        scanner = RepositoryScanner(supported_extensions={".rb"})
-        result = scanner.scan(root)
+        result = RepositoryScanner(supported_extensions={".rb"}).scan(root)
         names = {f.relative_path.name for f in result.files}
         assert names == {"script.rb"}
 
@@ -370,10 +340,150 @@ class TestSupportedExtensions:
         for ext in SUPPORTED_EXTENSIONS:
             (root / f"file{ext}").write_text("// code\n")
 
-        scanner = RepositoryScanner()
-        result = scanner.scan(root)
+        result = RepositoryScanner().scan(root)
         found_exts = {f.extension for f in result.files}
         assert found_exts == SUPPORTED_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Testes de PermissionError
+# ---------------------------------------------------------------------------
+
+
+class TestPermissionError:
+    """Testes de tratamento de erros de permissão."""
+
+    def test_permission_error_on_file_does_not_crash_scanner(self, tmp_path: Path) -> None:
+        """PermissionError ao ler um arquivo não deve interromper a varredura."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "readable.py").write_text("def ok(): pass\n")
+        (root / "unreadable.py").write_text("def secret(): pass\n")
+
+        original_stat = Path.stat
+
+        def mock_stat(self: Path, **kwargs: object) -> object:
+            if self.name == "unreadable.py":
+                raise PermissionError(f"Acesso negado: {self}")
+            return original_stat(self, **kwargs)
+
+        with patch.object(Path, "stat", mock_stat):
+            result = RepositoryScanner().scan(root)
+
+        # O arquivo legível deve ser encontrado
+        names = {f.relative_path.name for f in result.files}
+        assert "readable.py" in names
+        # O arquivo sem permissão deve ser contado como ignorado
+        assert result.skipped_files >= 1
+
+    def test_permission_error_on_count_lines_returns_zero(self, tmp_path: Path) -> None:
+        """PermissionError ao contar linhas deve retornar 0 sem lançar exceção."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "file.py").write_text("x = 1\n")
+
+        original_open = open
+
+        def mock_open(path: object, mode: str = "r", **kwargs: object) -> object:
+            if mode == "rb" and "file.py" in str(path):
+                raise PermissionError("Acesso negado")
+            return original_open(path, mode, **kwargs)  # type: ignore[call-overload]
+
+        with patch("builtins.open", mock_open):
+            result = RepositoryScanner().scan(root)
+
+        # O arquivo deve aparecer com line_count = 0
+        assert len(result.files) == 1
+        assert result.files[0].line_count == 0
+
+
+# ---------------------------------------------------------------------------
+# Testes de symlinks
+# ---------------------------------------------------------------------------
+
+
+class TestSymlinks:
+    """Testes de proteção contra symlinks."""
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlinks requerem privilégios no Windows")
+    def test_symlink_dir_is_ignored_by_default(self, tmp_path: Path) -> None:
+        """Diretório symlink não deve ser seguido quando follow_symlinks=False."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "main.py").write_text("def main(): pass\n")
+
+        # Cria um diretório real com arquivo e um symlink apontando para ele
+        real_dir = tmp_path / "real_lib"
+        real_dir.mkdir()
+        (real_dir / "lib.py").write_text("def lib(): pass\n")
+        link_dir = root / "linked_lib"
+        link_dir.symlink_to(real_dir)
+
+        scanner = RepositoryScanner(follow_symlinks=False)
+        result = scanner.scan(root)
+        names = {f.relative_path.name for f in result.files}
+
+        # lib.py não deve aparecer — o symlink foi ignorado
+        assert "lib.py" not in names
+        assert "main.py" in names
+
+    @pytest.mark.skipif(sys.platform == "win32", reason="Symlinks requerem privilégios no Windows")
+    def test_symlink_dir_is_followed_when_enabled(self, tmp_path: Path) -> None:
+        """Diretório symlink deve ser seguido quando follow_symlinks=True."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "main.py").write_text("def main(): pass\n")
+
+        real_dir = tmp_path / "real_lib"
+        real_dir.mkdir()
+        (real_dir / "lib.py").write_text("def lib(): pass\n")
+        link_dir = root / "linked_lib"
+        link_dir.symlink_to(real_dir)
+
+        scanner = RepositoryScanner(follow_symlinks=True)
+        result = scanner.scan(root)
+        names = {f.relative_path.name for f in result.files}
+
+        assert "lib.py" in names
+        assert "main.py" in names
+
+
+# ---------------------------------------------------------------------------
+# Testes de iter_files() — lazy/streaming
+# ---------------------------------------------------------------------------
+
+
+class TestIterFiles:
+    """Testes do método iter_files() para avaliação preguiçosa."""
+
+    def test_iter_files_yields_file_metadata(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """iter_files() deve gerar instâncias de FileMetadata."""
+        for metadata in scanner.iter_files(repo):
+            assert isinstance(metadata, FileMetadata)
+
+    def test_iter_files_same_files_as_scan(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """iter_files() deve retornar os mesmos arquivos que scan()."""
+        scan_names = {f.relative_path.name for f in scanner.scan(repo).files}
+        iter_names = {f.relative_path.name for f in scanner.iter_files(repo)}
+        assert scan_names == iter_names
+
+    def test_iter_files_invalid_directory_raises(self, scanner: RepositoryScanner, tmp_path: Path) -> None:
+        """iter_files() deve levantar NotADirectoryError para caminho inválido."""
+        with pytest.raises(NotADirectoryError):
+            list(scanner.iter_files(tmp_path / "nao_existe"))
+
+    def test_iter_files_is_generator(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """iter_files() deve retornar um generator (avaliação lazy)."""
+        import types
+        result = scanner.iter_files(repo)
+        assert isinstance(result, types.GeneratorType)
+
+    def test_iter_files_respects_ignore_dirs(self, repo: Path) -> None:
+        """iter_files() deve respeitar a lista de diretórios ignorados."""
+        scanner = RepositoryScanner()
+        paths = [str(f.relative_path) for f in scanner.iter_files(repo)]
+        assert not any(".git" in p for p in paths)
+        assert not any("node_modules" in p for p in paths)
 
 
 # ---------------------------------------------------------------------------
@@ -384,27 +494,23 @@ class TestSupportedExtensions:
 class TestScannerProperties:
     """Testes das propriedades públicas do scanner."""
 
-    def test_ignore_dirs_contains_defaults(self) -> None:
+    @pytest.mark.parametrize("expected_dir", [".git", "node_modules", "dist", "build", ".cache", "__pycache__"])
+    def test_ignore_dirs_contains_defaults(self, expected_dir: str) -> None:
         """ignore_dirs deve conter todos os diretórios padrão."""
-        scanner = RepositoryScanner()
-        for d in [".git", "node_modules", "dist", "build", ".cache", "__pycache__"]:
-            assert d in scanner.ignore_dirs
+        assert expected_dir in RepositoryScanner().ignore_dirs
 
-    def test_supported_extensions_contains_defaults(self) -> None:
+    @pytest.mark.parametrize("expected_ext", [".py", ".java", ".js", ".ts"])
+    def test_supported_extensions_contains_defaults(self, expected_ext: str) -> None:
         """supported_extensions deve conter as extensões padrão."""
-        scanner = RepositoryScanner()
-        for ext in [".py", ".java", ".js", ".ts"]:
-            assert ext in scanner.supported_extensions
+        assert expected_ext in RepositoryScanner().supported_extensions
 
     def test_ignore_dirs_is_frozenset(self) -> None:
         """ignore_dirs deve ser imutável (frozenset)."""
-        scanner = RepositoryScanner()
-        assert isinstance(scanner.ignore_dirs, frozenset)
+        assert isinstance(RepositoryScanner().ignore_dirs, frozenset)
 
     def test_supported_extensions_is_frozenset(self) -> None:
         """supported_extensions deve ser imutável (frozenset)."""
-        scanner = RepositoryScanner()
-        assert isinstance(scanner.supported_extensions, frozenset)
+        assert isinstance(RepositoryScanner().supported_extensions, frozenset)
 
 
 # ---------------------------------------------------------------------------
@@ -419,9 +525,7 @@ class TestEmptyDirectory:
         """Diretório vazio deve retornar ScanResult com zero arquivos."""
         root = tmp_path / "empty"
         root.mkdir()
-
-        scanner = RepositoryScanner()
-        result = scanner.scan(root)
+        result = RepositoryScanner().scan(root)
         assert result.total_files == 0
         assert result.files == []
 
@@ -431,7 +535,5 @@ class TestEmptyDirectory:
         root.mkdir()
         (root / "README.md").write_text("# Docs\n")
         (root / "config.yaml").write_text("key: value\n")
-
-        scanner = RepositoryScanner()
-        result = scanner.scan(root)
+        result = RepositoryScanner().scan(root)
         assert result.total_files == 0

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -1,0 +1,437 @@
+"""Testes unitários para o RepositoryScanner.
+
+Cobre:
+- Varredura básica de diretório
+- Aplicação de lista de ignores
+- Coleta de metadados (linguagem, extensão, tamanho, linhas)
+- Arquivos com extensão não suportada são ignorados
+- Diretórios ignorados por padrão (.git, node_modules, etc.)
+- Diretórios ignorados customizados
+- Arquivo maior que o limite é ignorado
+- Diretório inválido levanta NotADirectoryError
+- Propriedades do scanner (ignore_dirs, supported_extensions)
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from tokemize.core.parser.scanner import (
+    DEFAULT_IGNORE_DIRS,
+    EXTENSION_TO_LANGUAGE,
+    SUPPORTED_EXTENSIONS,
+    FileMetadata,
+    RepositoryScanner,
+    ScanResult,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """Cria um repositório fake com estrutura variada para testes.
+
+    Estrutura:
+        repo/
+        ├── main.py          (python)
+        ├── utils.py         (python)
+        ├── App.java         (java)
+        ├── index.js         (javascript)
+        ├── types.ts         (typescript)
+        ├── README.md        (ignorado — extensão não suportada)
+        ├── .git/
+        │   └── config       (ignorado — dir .git)
+        ├── node_modules/
+        │   └── lib.js       (ignorado — dir node_modules)
+        ├── dist/
+        │   └── bundle.js    (ignorado — dir dist)
+        ├── build/
+        │   └── output.py    (ignorado — dir build)
+        └── src/
+            └── helper.py    (python)
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    # Arquivos válidos
+    (root / "main.py").write_text("def main(): pass\n")
+    (root / "utils.py").write_text("import os\n\ndef helper(): pass\n")
+    (root / "App.java").write_text("public class App {}\n")
+    (root / "index.js").write_text("function init() {}\n")
+    (root / "types.ts").write_text("interface IFoo { bar(): void; }\n")
+
+    # Arquivo com extensão não suportada
+    (root / "README.md").write_text("# Readme\n")
+
+    # Diretórios ignorados
+    git_dir = root / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text("[core]\n")
+
+    nm_dir = root / "node_modules"
+    nm_dir.mkdir()
+    (nm_dir / "lib.js").write_text("module.exports = {};\n")
+
+    dist_dir = root / "dist"
+    dist_dir.mkdir()
+    (dist_dir / "bundle.js").write_text("(function(){})()\n")
+
+    build_dir = root / "build"
+    build_dir.mkdir()
+    (build_dir / "output.py").write_text("x = 1\n")
+
+    # Subdiretório válido
+    src_dir = root / "src"
+    src_dir.mkdir()
+    (src_dir / "helper.py").write_text("def helper(): return 42\n")
+
+    return root
+
+
+@pytest.fixture()
+def scanner() -> RepositoryScanner:
+    """Scanner com configuração padrão."""
+    return RepositoryScanner()
+
+
+# ---------------------------------------------------------------------------
+# Testes de varredura básica
+# ---------------------------------------------------------------------------
+
+
+class TestScanBasic:
+    """Testes de varredura básica do repositório."""
+
+    def test_scan_returns_scan_result(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """scan() deve retornar uma instância de ScanResult."""
+        result = scanner.scan(repo)
+        assert isinstance(result, ScanResult)
+
+    def test_scan_root_is_resolved(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """ScanResult.root deve ser o caminho resolvido (absoluto)."""
+        result = scanner.scan(repo)
+        assert result.root == repo.resolve()
+
+    def test_scan_finds_all_valid_files(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Deve encontrar exatamente os arquivos com extensão suportada fora de dirs ignorados."""
+        result = scanner.scan(repo)
+        names = {f.relative_path.name for f in result.files}
+        assert names == {"main.py", "utils.py", "App.java", "index.js", "types.ts", "helper.py"}
+
+    def test_scan_total_files_count(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """total_files deve refletir o número de arquivos válidos encontrados."""
+        result = scanner.scan(repo)
+        assert result.total_files == len(result.files)
+        assert result.total_files == 6
+
+    def test_scan_skipped_files_count(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """skipped_files deve contar arquivos com extensão não suportada."""
+        result = scanner.scan(repo)
+        # README.md é ignorado por extensão
+        assert result.skipped_files >= 1
+
+    def test_scan_invalid_directory_raises(self, scanner: RepositoryScanner, tmp_path: Path) -> None:
+        """scan() deve levantar NotADirectoryError para caminho inválido."""
+        fake_path = tmp_path / "nao_existe"
+        with pytest.raises(NotADirectoryError, match="nao_existe"):
+            scanner.scan(fake_path)
+
+    def test_scan_file_path_raises(self, scanner: RepositoryScanner, tmp_path: Path) -> None:
+        """scan() deve levantar NotADirectoryError se o caminho for um arquivo."""
+        file_path = tmp_path / "arquivo.py"
+        file_path.write_text("x = 1")
+        with pytest.raises(NotADirectoryError):
+            scanner.scan(file_path)
+
+
+# ---------------------------------------------------------------------------
+# Testes de diretórios ignorados
+# ---------------------------------------------------------------------------
+
+
+class TestIgnoreDirs:
+    """Testes de aplicação da lista de diretórios ignorados."""
+
+    def test_git_dir_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivos dentro de .git não devem aparecer no resultado."""
+        result = scanner.scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any(".git" in p for p in paths)
+
+    def test_node_modules_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivos dentro de node_modules não devem aparecer no resultado."""
+        result = scanner.scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any("node_modules" in p for p in paths)
+
+    def test_dist_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivos dentro de dist não devem aparecer no resultado."""
+        result = scanner.scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any("dist" in p for p in paths)
+
+    def test_build_is_ignored(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivos dentro de build não devem aparecer no resultado."""
+        result = scanner.scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any("build" in p for p in paths)
+
+    def test_custom_ignore_dir(self, repo: Path) -> None:
+        """Diretório customizado deve ser ignorado quando adicionado à lista."""
+        custom_dir = repo / "meu_cache"
+        custom_dir.mkdir()
+        (custom_dir / "cached.py").write_text("x = 1\n")
+
+        scanner = RepositoryScanner(ignore_dirs={"meu_cache"})
+        result = scanner.scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any("meu_cache" in p for p in paths)
+
+    def test_custom_ignore_merges_with_defaults(self, repo: Path) -> None:
+        """Ignorar customizado deve mesclar com DEFAULT_IGNORE_DIRS."""
+        scanner = RepositoryScanner(ignore_dirs={"extra_dir"})
+        # .git ainda deve ser ignorado
+        assert ".git" in scanner.ignore_dirs
+        assert "extra_dir" in scanner.ignore_dirs
+
+    def test_ignored_dirs_reported_in_result(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """ScanResult.ignored_dirs deve conter os diretórios que foram pulados."""
+        result = scanner.scan(repo)
+        assert ".git" in result.ignored_dirs or "node_modules" in result.ignored_dirs
+
+    def test_pycache_is_ignored(self, repo: Path) -> None:
+        """__pycache__ deve ser ignorado por padrão."""
+        cache_dir = repo / "__pycache__"
+        cache_dir.mkdir()
+        (cache_dir / "main.cpython-311.pyc").write_bytes(b"\x00\x00")
+
+        scanner = RepositoryScanner()
+        result = scanner.scan(repo)
+        paths = [str(f.relative_path) for f in result.files]
+        assert not any("__pycache__" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# Testes de metadados dos arquivos
+# ---------------------------------------------------------------------------
+
+
+class TestFileMetadata:
+    """Testes de coleta de metadados dos arquivos."""
+
+    def test_metadata_language_python(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivo .py deve ter linguagem 'python'."""
+        result = scanner.scan(repo)
+        py_files = [f for f in result.files if f.extension == ".py"]
+        assert all(f.language == "python" for f in py_files)
+
+    def test_metadata_language_java(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivo .java deve ter linguagem 'java'."""
+        result = scanner.scan(repo)
+        java_files = [f for f in result.files if f.extension == ".java"]
+        assert all(f.language == "java" for f in java_files)
+
+    def test_metadata_language_javascript(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivo .js deve ter linguagem 'javascript'."""
+        result = scanner.scan(repo)
+        js_files = [f for f in result.files if f.extension == ".js"]
+        assert all(f.language == "javascript" for f in js_files)
+
+    def test_metadata_language_typescript(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Arquivo .ts deve ter linguagem 'typescript'."""
+        result = scanner.scan(repo)
+        ts_files = [f for f in result.files if f.extension == ".ts"]
+        assert all(f.language == "typescript" for f in ts_files)
+
+    def test_metadata_size_bytes_positive(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """size_bytes deve ser maior que zero para arquivos não vazios."""
+        result = scanner.scan(repo)
+        assert all(f.size_bytes > 0 for f in result.files)
+
+    def test_metadata_line_count_positive(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """line_count deve ser maior que zero para arquivos não vazios."""
+        result = scanner.scan(repo)
+        assert all(f.line_count > 0 for f in result.files)
+
+    def test_metadata_line_count_accuracy(self, tmp_path: Path) -> None:
+        """line_count deve refletir o número real de linhas do arquivo."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        content = "line1\nline2\nline3\n"
+        (root / "test.py").write_text(content)
+
+        scanner = RepositoryScanner()
+        result = scanner.scan(root)
+        assert len(result.files) == 1
+        assert result.files[0].line_count == 3
+
+    def test_metadata_relative_path(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """relative_path deve ser relativo à raiz do repositório."""
+        result = scanner.scan(repo)
+        for f in result.files:
+            assert not f.relative_path.is_absolute()
+            assert str(f.relative_path) != str(f.path)
+
+    def test_metadata_absolute_path_exists(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """path deve ser absoluto e o arquivo deve existir."""
+        result = scanner.scan(repo)
+        for f in result.files:
+            assert f.path.is_absolute()
+            assert f.path.exists()
+
+    def test_metadata_extension_matches_suffix(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """extension deve corresponder ao sufixo do arquivo."""
+        result = scanner.scan(repo)
+        for f in result.files:
+            assert f.extension == f.path.suffix.lower()
+
+    def test_metadata_is_file_metadata_instance(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """Cada item em result.files deve ser uma instância de FileMetadata."""
+        result = scanner.scan(repo)
+        assert all(isinstance(f, FileMetadata) for f in result.files)
+
+
+# ---------------------------------------------------------------------------
+# Testes de limite de tamanho de arquivo
+# ---------------------------------------------------------------------------
+
+
+class TestFileSizeLimit:
+    """Testes de limite de tamanho de arquivo."""
+
+    def test_file_exceeding_size_limit_is_skipped(self, tmp_path: Path) -> None:
+        """Arquivo maior que max_file_size_bytes deve ser ignorado."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        big_file = root / "big.py"
+        big_file.write_bytes(b"x = 1\n" * 200)  # ~1200 bytes
+
+        scanner = RepositoryScanner(max_file_size_bytes=100)
+        result = scanner.scan(root)
+        assert result.total_files == 0
+        assert result.skipped_files == 1
+
+    def test_file_within_size_limit_is_included(self, tmp_path: Path) -> None:
+        """Arquivo dentro do limite deve ser incluído normalmente."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        small_file = root / "small.py"
+        small_file.write_text("x = 1\n")
+
+        scanner = RepositoryScanner(max_file_size_bytes=1024)
+        result = scanner.scan(root)
+        assert result.total_files == 1
+
+
+# ---------------------------------------------------------------------------
+# Testes de extensões suportadas
+# ---------------------------------------------------------------------------
+
+
+class TestSupportedExtensions:
+    """Testes de filtragem por extensão."""
+
+    def test_unsupported_extension_is_skipped(self, tmp_path: Path) -> None:
+        """Arquivos com extensão não suportada devem ser ignorados."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "notes.txt").write_text("hello\n")
+        (root / "data.json").write_text("{}\n")
+        (root / "style.css").write_text("body {}\n")
+
+        scanner = RepositoryScanner()
+        result = scanner.scan(root)
+        assert result.total_files == 0
+        assert result.skipped_files == 3
+
+    def test_custom_supported_extensions(self, tmp_path: Path) -> None:
+        """Scanner com extensões customizadas deve respeitar a lista fornecida."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "script.rb").write_text("puts 'hello'\n")
+        (root / "main.py").write_text("print('hi')\n")
+
+        scanner = RepositoryScanner(supported_extensions={".rb"})
+        result = scanner.scan(root)
+        names = {f.relative_path.name for f in result.files}
+        assert names == {"script.rb"}
+
+    def test_all_supported_extensions_are_found(self, tmp_path: Path) -> None:
+        """Todas as extensões suportadas devem ser detectadas."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        for ext in SUPPORTED_EXTENSIONS:
+            (root / f"file{ext}").write_text("// code\n")
+
+        scanner = RepositoryScanner()
+        result = scanner.scan(root)
+        found_exts = {f.extension for f in result.files}
+        assert found_exts == SUPPORTED_EXTENSIONS
+
+
+# ---------------------------------------------------------------------------
+# Testes de propriedades do scanner
+# ---------------------------------------------------------------------------
+
+
+class TestScannerProperties:
+    """Testes das propriedades públicas do scanner."""
+
+    def test_ignore_dirs_contains_defaults(self) -> None:
+        """ignore_dirs deve conter todos os diretórios padrão."""
+        scanner = RepositoryScanner()
+        for d in [".git", "node_modules", "dist", "build", ".cache", "__pycache__"]:
+            assert d in scanner.ignore_dirs
+
+    def test_supported_extensions_contains_defaults(self) -> None:
+        """supported_extensions deve conter as extensões padrão."""
+        scanner = RepositoryScanner()
+        for ext in [".py", ".java", ".js", ".ts"]:
+            assert ext in scanner.supported_extensions
+
+    def test_ignore_dirs_is_frozenset(self) -> None:
+        """ignore_dirs deve ser imutável (frozenset)."""
+        scanner = RepositoryScanner()
+        assert isinstance(scanner.ignore_dirs, frozenset)
+
+    def test_supported_extensions_is_frozenset(self) -> None:
+        """supported_extensions deve ser imutável (frozenset)."""
+        scanner = RepositoryScanner()
+        assert isinstance(scanner.supported_extensions, frozenset)
+
+
+# ---------------------------------------------------------------------------
+# Testes de diretório vazio
+# ---------------------------------------------------------------------------
+
+
+class TestEmptyDirectory:
+    """Testes com diretório vazio ou sem arquivos suportados."""
+
+    def test_empty_directory_returns_empty_result(self, tmp_path: Path) -> None:
+        """Diretório vazio deve retornar ScanResult com zero arquivos."""
+        root = tmp_path / "empty"
+        root.mkdir()
+
+        scanner = RepositoryScanner()
+        result = scanner.scan(root)
+        assert result.total_files == 0
+        assert result.files == []
+
+    def test_directory_with_only_ignored_files(self, tmp_path: Path) -> None:
+        """Diretório com apenas arquivos não suportados deve retornar zero arquivos válidos."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "README.md").write_text("# Docs\n")
+        (root / "config.yaml").write_text("key: value\n")
+
+        scanner = RepositoryScanner()
+        result = scanner.scan(root)
+        assert result.total_files == 0

--- a/tests/test_tree_sitter_analyzer.py
+++ b/tests/test_tree_sitter_analyzer.py
@@ -533,3 +533,50 @@ class TestArtifactInvariants:
         artifacts = analyzer.analyze(f)
         for a in artifacts:
             assert a.content.strip() != ""
+
+
+# ---------------------------------------------------------------------------
+# Testes diretos do modelo Artifact (__post_init__)
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactModel:
+    """Testes das validações do dataclass Artifact."""
+
+    def test_artifact_invalid_start_end_line_raises(self) -> None:
+        """Artifact com start_line > end_line deve levantar ValueError."""
+        with pytest.raises(ValueError, match="start_line"):
+            Artifact(
+                name="foo",
+                type="function",
+                start_line=10,
+                end_line=5,  # inválido
+                language="python",
+                content="def foo(): pass",
+            )
+
+    def test_artifact_invalid_type_raises(self) -> None:
+        """Artifact com type inválido deve levantar ValueError."""
+        with pytest.raises(ValueError, match="Tipo inválido"):
+            Artifact(
+                name="foo",
+                type="variable",  # inválido
+                start_line=1,
+                end_line=1,
+                language="python",
+                content="x = 1",
+            )
+
+    def test_artifact_valid_construction(self) -> None:
+        """Artifact com dados válidos deve ser criado sem exceção."""
+        a = Artifact(
+            name="my_func",
+            type="function",
+            start_line=1,
+            end_line=3,
+            language="python",
+            content="def my_func(): pass",
+        )
+        assert a.name == "my_func"
+        assert a.type == "function"
+        assert a.file_path == ""  # default

--- a/tests/test_tree_sitter_analyzer.py
+++ b/tests/test_tree_sitter_analyzer.py
@@ -1,0 +1,535 @@
+"""Testes unitários para o TreeSitterAnalyzer.
+
+Cobre:
+- Extração de artefatos Python (imports, funções, classes, métodos)
+- Extração de artefatos Java (imports, classes, métodos)
+- Extração de artefatos JavaScript (imports, funções, classes, métodos, arrow fns)
+- Extração de artefatos TypeScript (imports, funções, classes, interfaces, métodos)
+- Metadados obrigatórios em todos os artefatos
+- Preservação do conteúdo textual original
+- UnsupportedLanguageError para extensões não suportadas
+- FileNotFoundError para arquivos inexistentes
+- analyze_many() ignora erros e continua
+- detect_language() detecta corretamente
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokemize.core.parser.tree_sitter_analyzer import (
+    SUPPORTED_LANGUAGES,
+    TreeSitterAnalyzer,
+    UnsupportedLanguageError,
+)
+from tokemize.models.artifact import Artifact
+
+VALID_ARTIFACT_TYPES = {"function", "class", "method", "import"}
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def analyzer() -> TreeSitterAnalyzer:
+    """Instância padrão do TreeSitterAnalyzer."""
+    return TreeSitterAnalyzer()
+
+
+def _write(tmp_path: Path, filename: str, content: str) -> Path:
+    """Escreve um arquivo temporário e retorna seu Path."""
+    p = tmp_path / filename
+    p.write_text(content, encoding="utf-8")
+    return p
+
+
+# ---------------------------------------------------------------------------
+# Helpers de asserção
+# ---------------------------------------------------------------------------
+
+
+def _assert_artifact_valid(artifact: Artifact, language: str) -> None:
+    """Verifica que um artefato possui todos os metadados obrigatórios."""
+    assert artifact.name, f"name vazio em {artifact}"
+    assert artifact.type in VALID_ARTIFACT_TYPES, f"type inválido: {artifact.type}"
+    assert artifact.start_line >= 1, f"start_line < 1: {artifact}"
+    assert artifact.end_line >= artifact.start_line, f"end_line < start_line: {artifact}"
+    assert artifact.language == language, f"language errada: {artifact.language}"
+    assert artifact.content, f"content vazio em {artifact}"
+
+
+def _find(artifacts: list[Artifact], name: str, type_: str) -> Artifact | None:
+    """Encontra um artefato pelo nome e tipo."""
+    return next(
+        (a for a in artifacts if a.name == name and a.type == type_), None
+    )
+
+
+# ---------------------------------------------------------------------------
+# Testes Python
+# ---------------------------------------------------------------------------
+
+
+class TestPythonExtraction:
+    """Testes de extração de artefatos Python."""
+
+    PYTHON_CODE = """\
+import os
+from pathlib import Path
+
+class MyClass:
+    def my_method(self, x: int) -> str:
+        return str(x)
+
+    def another_method(self):
+        pass
+
+def standalone_func(a, b):
+    return a + b
+
+def another_func():
+    pass
+"""
+
+    def test_extracts_import_statement(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair import_statement como artefato do tipo 'import'."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        imp = _find(artifacts, "os", "import")
+        assert imp is not None
+
+    def test_extracts_from_import(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair import_from_statement como artefato do tipo 'import'."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        imp = next((a for a in artifacts if a.type == "import" and "pathlib" in a.name), None)
+        assert imp is not None
+
+    def test_extracts_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair class_definition como artefato do tipo 'class'."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        cls = _find(artifacts, "MyClass", "class")
+        assert cls is not None
+
+    def test_extracts_methods_inside_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair funções dentro de classe como tipo 'method'."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        method = _find(artifacts, "my_method", "method")
+        assert method is not None
+        another = _find(artifacts, "another_method", "method")
+        assert another is not None
+
+    def test_extracts_top_level_function(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair funções top-level como tipo 'function'."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        func = _find(artifacts, "standalone_func", "function")
+        assert func is not None
+
+    def test_does_not_extract_method_as_function(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Métodos dentro de classe não devem aparecer como 'function'."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        wrong = _find(artifacts, "my_method", "function")
+        assert wrong is None
+
+    def test_all_artifacts_have_valid_metadata(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos Python devem ter metadados válidos."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        assert len(artifacts) > 0
+        for a in artifacts:
+            _assert_artifact_valid(a, "python")
+
+    def test_content_preserves_original_text(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """O campo content deve preservar o texto original do artefato."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        func = _find(artifacts, "standalone_func", "function")
+        assert func is not None
+        assert "def standalone_func" in func.content
+        assert "return a + b" in func.content
+
+    def test_start_end_line_accuracy(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """start_line e end_line devem corresponder às linhas reais no arquivo."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        imp_os = _find(artifacts, "os", "import")
+        assert imp_os is not None
+        assert imp_os.start_line == 1
+        assert imp_os.end_line == 1
+
+    def test_file_path_in_artifact(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """file_path no artefato deve corresponder ao arquivo analisado."""
+        f = _write(tmp_path, "code.py", self.PYTHON_CODE)
+        artifacts = analyzer.analyze(f)
+        assert all(a.file_path == str(f) for a in artifacts)
+
+    def test_empty_file_returns_empty_list(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Arquivo Python vazio deve retornar lista vazia."""
+        f = _write(tmp_path, "empty.py", "")
+        artifacts = analyzer.analyze(f)
+        assert artifacts == []
+
+    def test_only_comments_returns_empty_list(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Arquivo com apenas comentários não deve gerar artefatos."""
+        f = _write(tmp_path, "comments.py", "# apenas um comentário\n# outro\n")
+        artifacts = analyzer.analyze(f)
+        assert artifacts == []
+
+    def test_decorated_function_extracted(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Função decorada deve ser extraída corretamente."""
+        code = "@staticmethod\ndef decorated(): pass\n"
+        f = _write(tmp_path, "deco.py", code)
+        artifacts = analyzer.analyze(f)
+        func = _find(artifacts, "decorated", "function")
+        assert func is not None
+
+
+# ---------------------------------------------------------------------------
+# Testes Java
+# ---------------------------------------------------------------------------
+
+
+class TestJavaExtraction:
+    """Testes de extração de artefatos Java."""
+
+    JAVA_CODE = """\
+import java.util.List;
+import java.io.IOException;
+
+public class MyService {
+    public void processItems(List<String> items) {
+        // process
+    }
+
+    private int calculate(int x) {
+        return x * 2;
+    }
+}
+"""
+
+    def test_extracts_import(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair import_declaration como tipo 'import'."""
+        f = _write(tmp_path, "MyService.java", self.JAVA_CODE)
+        artifacts = analyzer.analyze(f)
+        imports = [a for a in artifacts if a.type == "import"]
+        assert len(imports) == 2
+
+    def test_extracts_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair class_declaration como tipo 'class'."""
+        f = _write(tmp_path, "MyService.java", self.JAVA_CODE)
+        artifacts = analyzer.analyze(f)
+        cls = _find(artifacts, "MyService", "class")
+        assert cls is not None
+
+    def test_extracts_methods(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair method_declaration como tipo 'method'."""
+        f = _write(tmp_path, "MyService.java", self.JAVA_CODE)
+        artifacts = analyzer.analyze(f)
+        m1 = _find(artifacts, "processItems", "method")
+        m2 = _find(artifacts, "calculate", "method")
+        assert m1 is not None
+        assert m2 is not None
+
+    def test_all_artifacts_have_valid_metadata(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos Java devem ter metadados válidos."""
+        f = _write(tmp_path, "MyService.java", self.JAVA_CODE)
+        artifacts = analyzer.analyze(f)
+        assert len(artifacts) > 0
+        for a in artifacts:
+            _assert_artifact_valid(a, "java")
+
+    def test_content_preserves_original_text(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """O campo content deve preservar o texto original do método Java."""
+        f = _write(tmp_path, "MyService.java", self.JAVA_CODE)
+        artifacts = analyzer.analyze(f)
+        method = _find(artifacts, "calculate", "method")
+        assert method is not None
+        assert "calculate" in method.content
+        assert "return x * 2" in method.content
+
+
+# ---------------------------------------------------------------------------
+# Testes JavaScript
+# ---------------------------------------------------------------------------
+
+
+class TestJavaScriptExtraction:
+    """Testes de extração de artefatos JavaScript."""
+
+    JS_CODE = (
+        "class Calculator {\n"
+        "    add(a, b) { return a + b; }\n"
+        "    subtract(a, b) { return a - b; }\n"
+        "}\n"
+        "\n"
+        "function greet(name) {\n"
+        "    return 'Hello ' + name;\n"
+        "}\n"
+        "\n"
+        "const multiply = (a, b) => a * b;\n"
+        "const divide = function(a, b) { return a / b; };\n"
+    )
+
+    def test_extracts_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair class_declaration como tipo 'class'."""
+        f = _write(tmp_path, "calc.js", self.JS_CODE)
+        artifacts = analyzer.analyze(f)
+        cls = _find(artifacts, "Calculator", "class")
+        assert cls is not None
+
+    def test_extracts_methods_inside_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair method_definition dentro de classe como tipo 'method'."""
+        f = _write(tmp_path, "calc.js", self.JS_CODE)
+        artifacts = analyzer.analyze(f)
+        add = _find(artifacts, "add", "method")
+        sub = _find(artifacts, "subtract", "method")
+        assert add is not None
+        assert sub is not None
+
+    def test_extracts_function_declaration(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair function_declaration como tipo 'function'."""
+        f = _write(tmp_path, "calc.js", self.JS_CODE)
+        artifacts = analyzer.analyze(f)
+        func = _find(artifacts, "greet", "function")
+        assert func is not None
+
+    def test_extracts_arrow_function(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair arrow function como tipo 'function'."""
+        f = _write(tmp_path, "calc.js", self.JS_CODE)
+        artifacts = analyzer.analyze(f)
+        arrow = _find(artifacts, "multiply", "function")
+        assert arrow is not None
+
+    def test_extracts_function_expression(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair function expression como tipo 'function'."""
+        f = _write(tmp_path, "calc.js", self.JS_CODE)
+        artifacts = analyzer.analyze(f)
+        fn_expr = _find(artifacts, "divide", "function")
+        assert fn_expr is not None
+
+    def test_all_artifacts_have_valid_metadata(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos JavaScript devem ter metadados válidos."""
+        f = _write(tmp_path, "calc.js", self.JS_CODE)
+        artifacts = analyzer.analyze(f)
+        assert len(artifacts) > 0
+        for a in artifacts:
+            _assert_artifact_valid(a, "javascript")
+
+
+# ---------------------------------------------------------------------------
+# Testes TypeScript
+# ---------------------------------------------------------------------------
+
+
+class TestTypeScriptExtraction:
+    """Testes de extração de artefatos TypeScript."""
+
+    TS_CODE = (
+        "interface IShape {\n"
+        "    area(): number;\n"
+        "}\n"
+        "\n"
+        "class Circle implements IShape {\n"
+        "    constructor(private radius: number) {}\n"
+        "    area(): number { return Math.PI * this.radius ** 2; }\n"
+        "}\n"
+        "\n"
+        "function createCircle(r: number): Circle {\n"
+        "    return new Circle(r);\n"
+        "}\n"
+    )
+
+    def test_extracts_interface_as_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair interface_declaration como tipo 'class'."""
+        f = _write(tmp_path, "shapes.ts", self.TS_CODE)
+        artifacts = analyzer.analyze(f)
+        iface = _find(artifacts, "IShape", "class")
+        assert iface is not None
+
+    def test_extracts_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair class_declaration como tipo 'class'."""
+        f = _write(tmp_path, "shapes.ts", self.TS_CODE)
+        artifacts = analyzer.analyze(f)
+        cls = _find(artifacts, "Circle", "class")
+        assert cls is not None
+
+    def test_extracts_methods_inside_class(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair métodos dentro de classe TypeScript como tipo 'method'."""
+        f = _write(tmp_path, "shapes.ts", self.TS_CODE)
+        artifacts = analyzer.analyze(f)
+        method = _find(artifacts, "area", "method")
+        assert method is not None
+
+    def test_extracts_function(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Deve extrair function_declaration TypeScript como tipo 'function'."""
+        f = _write(tmp_path, "shapes.ts", self.TS_CODE)
+        artifacts = analyzer.analyze(f)
+        func = _find(artifacts, "createCircle", "function")
+        assert func is not None
+
+    def test_all_artifacts_have_valid_metadata(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos TypeScript devem ter metadados válidos."""
+        f = _write(tmp_path, "shapes.ts", self.TS_CODE)
+        artifacts = analyzer.analyze(f)
+        assert len(artifacts) > 0
+        for a in artifacts:
+            _assert_artifact_valid(a, "typescript")
+
+
+# ---------------------------------------------------------------------------
+# Testes de erros e edge cases
+# ---------------------------------------------------------------------------
+
+
+class TestErrorHandling:
+    """Testes de tratamento de erros e casos extremos."""
+
+    def test_unsupported_extension_raises(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Extensão não suportada deve levantar UnsupportedLanguageError."""
+        f = _write(tmp_path, "script.rb", "puts 'hello'\n")
+        with pytest.raises(UnsupportedLanguageError) as exc_info:
+            analyzer.analyze(f)
+        assert ".rb" in str(exc_info.value)
+
+    def test_unsupported_extension_error_message(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Mensagem de erro deve indicar a extensão não suportada."""
+        f = _write(tmp_path, "data.csv", "a,b,c\n")
+        with pytest.raises(UnsupportedLanguageError) as exc_info:
+            analyzer.analyze(f)
+        assert ".csv" in str(exc_info.value)
+
+    def test_file_not_found_raises(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Arquivo inexistente deve levantar FileNotFoundError."""
+        fake = tmp_path / "nao_existe.py"
+        with pytest.raises(FileNotFoundError):
+            analyzer.analyze(fake)
+
+    def test_syntax_error_returns_partial_artifacts(
+        self, analyzer: TreeSitterAnalyzer, tmp_path: Path
+    ) -> None:
+        """Arquivo com erro de sintaxe deve retornar artefatos válidos parcialmente."""
+        code = "def valid_func():\n    pass\n\ndef broken(\n"
+        f = _write(tmp_path, "broken.py", code)
+        # Não deve levantar exceção
+        artifacts = analyzer.analyze(f)
+        # A função válida deve ser extraída
+        func = _find(artifacts, "valid_func", "function")
+        assert func is not None
+
+    def test_analyze_many_skips_unsupported(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """analyze_many() deve ignorar arquivos não suportados e continuar."""
+        py_file = _write(tmp_path, "code.py", "def foo(): pass\n")
+        rb_file = _write(tmp_path, "script.rb", "puts 'hi'\n")
+
+        artifacts = analyzer.analyze_many([py_file, rb_file])
+        names = [a.name for a in artifacts]
+        assert "foo" in names
+
+    def test_analyze_many_skips_missing_files(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """analyze_many() deve ignorar arquivos inexistentes e continuar."""
+        py_file = _write(tmp_path, "code.py", "def bar(): pass\n")
+        missing = tmp_path / "ghost.py"
+
+        artifacts = analyzer.analyze_many([py_file, missing])
+        names = [a.name for a in artifacts]
+        assert "bar" in names
+
+    def test_analyze_many_concatenates_results(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """analyze_many() deve concatenar artefatos de todos os arquivos."""
+        f1 = _write(tmp_path, "a.py", "def func_a(): pass\n")
+        f2 = _write(tmp_path, "b.py", "def func_b(): pass\n")
+
+        artifacts = analyzer.analyze_many([f1, f2])
+        names = [a.name for a in artifacts]
+        assert "func_a" in names
+        assert "func_b" in names
+
+
+# ---------------------------------------------------------------------------
+# Testes de detect_language
+# ---------------------------------------------------------------------------
+
+
+class TestDetectLanguage:
+    """Testes do método detect_language."""
+
+    @pytest.mark.parametrize(
+        "filename, expected_language",
+        [
+            ("script.py", "python"),
+            ("App.java", "java"),
+            ("index.js", "javascript"),
+            ("types.ts", "typescript"),
+        ],
+    )
+    def test_detect_language_by_extension(
+        self,
+        analyzer: TreeSitterAnalyzer,
+        tmp_path: Path,
+        filename: str,
+        expected_language: str,
+    ) -> None:
+        """detect_language() deve retornar a linguagem correta para cada extensão."""
+        f = tmp_path / filename
+        assert analyzer.detect_language(f) == expected_language
+
+    def test_detect_language_unsupported_raises(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """detect_language() deve levantar UnsupportedLanguageError para extensão desconhecida."""
+        f = tmp_path / "file.xyz"
+        with pytest.raises(UnsupportedLanguageError):
+            analyzer.detect_language(f)
+
+    def test_detect_language_case_insensitive(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """detect_language() deve ser case-insensitive para extensões."""
+        f = tmp_path / "Script.PY"
+        # A extensão é normalizada para lowercase no analyzer
+        assert analyzer.detect_language(f) == "python"
+
+
+# ---------------------------------------------------------------------------
+# Testes de invariantes do modelo Artifact
+# ---------------------------------------------------------------------------
+
+
+class TestArtifactInvariants:
+    """Testes das invariantes do dataclass Artifact."""
+
+    def test_artifact_start_line_lte_end_line(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos devem ter start_line <= end_line."""
+        code = "import os\nclass Foo:\n    def bar(self): pass\ndef baz(): pass\n"
+        f = _write(tmp_path, "inv.py", code)
+        artifacts = analyzer.analyze(f)
+        for a in artifacts:
+            assert a.start_line <= a.end_line, f"Invariante violada: {a}"
+
+    def test_artifact_type_is_valid(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos devem ter type em {'function','class','method','import'}."""
+        code = "import os\nclass Foo:\n    def bar(self): pass\ndef baz(): pass\n"
+        f = _write(tmp_path, "types.py", code)
+        artifacts = analyzer.analyze(f)
+        for a in artifacts:
+            assert a.type in VALID_ARTIFACT_TYPES
+
+    def test_artifact_name_not_empty(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos devem ter name não vazio."""
+        code = "import os\nclass Foo:\n    def bar(self): pass\ndef baz(): pass\n"
+        f = _write(tmp_path, "names.py", code)
+        artifacts = analyzer.analyze(f)
+        for a in artifacts:
+            assert a.name.strip() != ""
+
+    def test_artifact_content_not_empty(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos devem ter content não vazio."""
+        code = "import os\nclass Foo:\n    def bar(self): pass\ndef baz(): pass\n"
+        f = _write(tmp_path, "content.py", code)
+        artifacts = analyzer.analyze(f)
+        for a in artifacts:
+            assert a.content.strip() != ""


### PR DESCRIPTION
## O que foi feito?

- Adiciona \RepositoryScanner\ para percorrer repositórios com lista de diretórios ignorados (\.git\, \
ode_modules\, \dist\, \uild\, \__pycache__\, etc.)
- Coleta metadados dos arquivos: linguagem, extensão, tamanho e contagem de linhas
- Adiciona \TreeSitterAnalyzer\ para extração estrutural de artefatos via Tree-sitter (Python, Java, JavaScript, TypeScript)
- Extrai classes, funções, métodos e imports com nome, tipo, linhas e conteúdo original preservado
- Adiciona dataclass \Artifact\ com validação de invariantes
- Refatora extração para usar \child_by_field_name()\ — API declarativa do Tree-sitter
- Adiciona proteção contra symlinks recursivos e método \iter_files()\ lazy
- 104 testes unitários passando (2 skipped no Windows por symlinks)
- Configura \pyproject.toml\ com dependências e pytest

## Tipo de mudança
- [x] feature
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] hotfix

## Checklist
- [x] A branch segue o padrão correto
- [x] O PR está apontando para a branch correta
- [x] Testes foram executados
- [x] Não há arquivos desnecessários