### PR TITLE
feat(parser): adiciona modulos publicos, char_count e consumibilidade…

### DIFF
--- a/src/tokemize/core/parser/repository_parser.py
+++ b/src/tokemize/core/parser/repository_parser.py
@@ -1,0 +1,275 @@
+"""Integração entre Scanner e TreeSitterAnalyzer para o Tokemize.
+
+Orquestra o fluxo completo de análise de repositório:
+    RepositoryScanner → [FileMetadata] → TreeSitterAnalyzer → [Artifact]
+
+Este módulo é o elo entre as duas camadas de análise, expondo uma interface
+única (parse_repository) que recebe um diretório e retorna todos os artefatos
+estruturais extraídos dos arquivos de código encontrados.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+
+from tokemize.core.parser.scanner import FileMetadata, RepositoryScanner
+from tokemize.core.parser.tree_sitter_analyzer import TreeSitterAnalyzer
+from tokemize.models.artifact import Artifact
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class RepositoryParseResult:
+    """Resultado completo da análise de um repositório.
+
+    Contém tanto os metadados dos arquivos encontrados pelo scanner quanto
+    os artefatos estruturais extraídos pelo analyzer, além de estatísticas
+    de execução.
+
+    Attributes:
+        root: Diretório raiz analisado.
+        files: Lista de metadados dos arquivos encontrados pelo scanner.
+        artifacts: Lista de artefatos extraídos pelo analyzer.
+        total_files: Total de arquivos válidos encontrados.
+        total_artifacts: Total de artefatos extraídos.
+        skipped_files: Arquivos ignorados (extensão não suportada ou erro).
+        failed_files: Arquivos que falharam na análise sintática.
+        elapsed_seconds: Tempo total de execução em segundos.
+    """
+
+    root: Path
+    files: list[FileMetadata] = field(default_factory=list)
+    artifacts: list[Artifact] = field(default_factory=list)
+    total_files: int = 0
+    total_artifacts: int = 0
+    skipped_files: int = 0
+    failed_files: int = 0
+    elapsed_seconds: float = 0.0
+
+    def artifacts_by_file(self) -> dict[str, list[Artifact]]:
+        """Agrupa artefatos por caminho de arquivo.
+
+        Returns:
+            Dicionário mapeando file_path → lista de Artifact.
+
+        Example:
+            >>> result = parse_repository(Path("/repo"))
+            >>> by_file = result.artifacts_by_file()
+            >>> for path, arts in by_file.items():
+            ...     print(path, len(arts))
+        """
+        grouped: dict[str, list[Artifact]] = {}
+        for artifact in self.artifacts:
+            grouped.setdefault(artifact.file_path, []).append(artifact)
+        return grouped
+
+    def artifacts_by_type(self) -> dict[str, list[Artifact]]:
+        """Agrupa artefatos por tipo (function, class, method, import).
+
+        Returns:
+            Dicionário mapeando type → lista de Artifact.
+        """
+        grouped: dict[str, list[Artifact]] = {}
+        for artifact in self.artifacts:
+            grouped.setdefault(artifact.type, []).append(artifact)
+        return grouped
+
+    def artifacts_by_language(self) -> dict[str, list[Artifact]]:
+        """Agrupa artefatos por linguagem de programação.
+
+        Returns:
+            Dicionário mapeando language → lista de Artifact.
+        """
+        grouped: dict[str, list[Artifact]] = {}
+        for artifact in self.artifacts:
+            grouped.setdefault(artifact.language, []).append(artifact)
+        return grouped
+
+    def summary(self) -> str:
+        """Retorna um resumo legível do resultado da análise.
+
+        Returns:
+            String formatada com as principais métricas.
+        """
+        by_type = self.artifacts_by_type()
+        by_lang = self.artifacts_by_language()
+        lines = [
+            f"Repositório: {self.root}",
+            f"Arquivos analisados : {self.total_files}",
+            f"Arquivos ignorados  : {self.skipped_files}",
+            f"Arquivos com falha  : {self.failed_files}",
+            f"Artefatos extraídos : {self.total_artifacts}",
+            f"  classes   : {len(by_type.get('class', []))}",
+            f"  funções   : {len(by_type.get('function', []))}",
+            f"  métodos   : {len(by_type.get('method', []))}",
+            f"  imports   : {len(by_type.get('import', []))}",
+            f"Linguagens          : {', '.join(sorted(by_lang.keys())) or 'nenhuma'}",
+            f"Tempo de execução   : {self.elapsed_seconds:.3f}s",
+        ]
+        return "\n".join(lines)
+
+
+class RepositoryParser:
+    """Orquestra Scanner + TreeSitterAnalyzer para análise completa de repositório.
+
+    Combina o RepositoryScanner (varredura de arquivos) com o TreeSitterAnalyzer
+    (extração de artefatos) em um único fluxo coeso.
+
+    Args:
+        scanner: Instância de RepositoryScanner. Cria uma com defaults se None.
+        analyzer: Instância de TreeSitterAnalyzer. Cria uma com defaults se None.
+
+    Example:
+        >>> parser = RepositoryParser()
+        >>> result = parser.parse(Path("/meu/projeto"))
+        >>> print(result.summary())
+        >>> for artifact in result.artifacts:
+        ...     print(artifact.type, artifact.name, artifact.file_path)
+    """
+
+    def __init__(
+        self,
+        scanner: RepositoryScanner | None = None,
+        analyzer: TreeSitterAnalyzer | None = None,
+    ) -> None:
+        self._scanner = scanner or RepositoryScanner()
+        self._analyzer = analyzer or TreeSitterAnalyzer()
+
+    @property
+    def scanner(self) -> RepositoryScanner:
+        """Scanner configurado para este parser."""
+        return self._scanner
+
+    @property
+    def analyzer(self) -> TreeSitterAnalyzer:
+        """Analyzer configurado para este parser."""
+        return self._analyzer
+
+    def parse(self, root: Path) -> RepositoryParseResult:
+        """Executa o pipeline completo: scan → analyze → resultado.
+
+        1. Scanner percorre o repositório e coleta FileMetadata
+        2. Analyzer extrai artefatos de cada arquivo encontrado
+        3. Retorna RepositoryParseResult com tudo consolidado
+
+        Args:
+            root: Diretório raiz do repositório a ser analisado.
+
+        Returns:
+            RepositoryParseResult com arquivos, artefatos e métricas.
+
+        Raises:
+            NotADirectoryError: Se `root` não for um diretório válido.
+        """
+        start = time.perf_counter()
+        root = Path(root).resolve()
+
+        logger.info("Iniciando análise do repositório: %s", root)
+
+        # Etapa 1: Scanner
+        scan_result = self._scanner.scan(root)
+        logger.info(
+            "Scanner concluído: %d arquivos encontrados, %d ignorados",
+            scan_result.total_files,
+            scan_result.skipped_files,
+        )
+
+        result = RepositoryParseResult(
+            root=root,
+            files=scan_result.files,
+            total_files=scan_result.total_files,
+            skipped_files=scan_result.skipped_files,
+        )
+
+        # Etapa 2: Analyzer — processa cada arquivo encontrado
+        for file_meta in scan_result.files:
+            try:
+                artifacts = self._analyzer.analyze(file_meta.path)
+                result.artifacts.extend(artifacts)
+                logger.debug(
+                    "Arquivo '%s': %d artefatos extraídos",
+                    file_meta.relative_path,
+                    len(artifacts),
+                )
+            except Exception as exc:  # noqa: BLE001
+                result.failed_files += 1
+                logger.error(
+                    "Falha ao analisar '%s': %s",
+                    file_meta.relative_path,
+                    exc,
+                    exc_info=True,
+                )
+
+        result.total_artifacts = len(result.artifacts)
+        result.elapsed_seconds = time.perf_counter() - start
+
+        logger.info(
+            "Análise concluída: %d artefatos em %.3fs",
+            result.total_artifacts,
+            result.elapsed_seconds,
+        )
+        return result
+
+    def parse_streaming(self, root: Path):
+        """Versão lazy do parse — gera artefatos à medida que os encontra.
+
+        Usa iter_files() do scanner para não acumular FileMetadata em memória.
+        Ideal para repositórios muito grandes.
+
+        Args:
+            root: Diretório raiz do repositório.
+
+        Yields:
+            Artifact extraído de cada arquivo válido encontrado.
+
+        Raises:
+            NotADirectoryError: Se `root` não for um diretório válido.
+        """
+        root = Path(root).resolve()
+        logger.info("Iniciando análise streaming do repositório: %s", root)
+
+        for file_meta in self._scanner.iter_files(root):
+            try:
+                artifacts = self._analyzer.analyze(file_meta.path)
+                yield from artifacts
+            except Exception as exc:  # noqa: BLE001
+                logger.error(
+                    "Falha ao analisar '%s': %s",
+                    file_meta.path,
+                    exc,
+                    exc_info=True,
+                )
+
+
+def parse_repository(
+    root: Path,
+    ignore_dirs: set[str] | None = None,
+    max_file_size_bytes: int = 1024 * 1024,
+) -> RepositoryParseResult:
+    """Função de conveniência para análise completa de um repositório.
+
+    Cria um RepositoryParser com configurações opcionais e executa o pipeline.
+
+    Args:
+        root: Diretório raiz do repositório a ser analisado.
+        ignore_dirs: Diretórios adicionais a ignorar (mescla com os padrões).
+        max_file_size_bytes: Tamanho máximo de arquivo em bytes. Padrão: 1 MB.
+
+    Returns:
+        RepositoryParseResult com arquivos, artefatos e métricas.
+
+    Example:
+        >>> from tokemize.core.parser.repository_parser import parse_repository
+        >>> result = parse_repository(Path("/meu/projeto"))
+        >>> print(result.summary())
+    """
+    scanner = RepositoryScanner(
+        ignore_dirs=ignore_dirs,
+        max_file_size_bytes=max_file_size_bytes,
+    )
+    parser = RepositoryParser(scanner=scanner)
+    return parser.parse(root)

--- a/src/tokemize/core/parser/scanner.py
+++ b/src/tokemize/core/parser/scanner.py
@@ -76,6 +76,7 @@ class FileMetadata:
         extension: Extensão do arquivo (ex: ".py").
         size_bytes: Tamanho do arquivo em bytes.
         line_count: Número de linhas do arquivo.
+        char_count: Número de caracteres (codepoints UTF-8) do arquivo.
     """
 
     path: Path
@@ -84,6 +85,7 @@ class FileMetadata:
     extension: str
     size_bytes: int
     line_count: int = 0
+    char_count: int = 0
 
 
 @dataclass
@@ -347,6 +349,7 @@ class RepositoryScanner:
                 return None
 
             line_count = self._count_lines(file_path)
+            char_count = self._count_chars(file_path)
             language = EXTENSION_TO_LANGUAGE.get(ext, "unknown")
 
             return FileMetadata(
@@ -356,6 +359,7 @@ class RepositoryScanner:
                 extension=ext,
                 size_bytes=size,
                 line_count=line_count,
+                char_count=char_count,
             )
         except (OSError, PermissionError) as exc:
             logger.warning("Não foi possível ler o arquivo %s: %s", file_path, exc)
@@ -373,5 +377,19 @@ class RepositoryScanner:
         try:
             with open(file_path, "rb") as f:
                 return sum(1 for _ in f)
+        except (OSError, PermissionError):
+            return 0
+
+    def _count_chars(self, file_path: Path) -> int:
+        """Conta o número de caracteres (codepoints UTF-8) de um arquivo.
+
+        Args:
+            file_path: Caminho do arquivo.
+
+        Returns:
+            Número de caracteres ou 0 em caso de erro de leitura.
+        """
+        try:
+            return len(file_path.read_text(encoding="utf-8", errors="replace"))
         except (OSError, PermissionError):
             return 0

--- a/src/tokemize/models/artifact.py
+++ b/src/tokemize/models/artifact.py
@@ -1,6 +1,10 @@
 """Modelo de dados para artefatos extraídos do código-fonte."""
 
+from __future__ import annotations
+
+import dataclasses
 from dataclasses import dataclass
+from typing import Any
 
 
 @dataclass
@@ -41,3 +45,26 @@ class Artifact:
             raise ValueError(
                 f"Tipo inválido '{self.type}'. Tipos válidos: {valid_types}"
             )
+
+    def to_dict(self) -> dict[str, Any]:
+        """Serializa o artefato para um dicionário consumível pelo próximo módulo.
+
+        Permite integração direta com o Indexer, Selector e qualquer camada
+        downstream que precise de uma representação estruturada do artefato.
+
+        Returns:
+            Dicionário com todos os campos do artefato.
+
+        Example:
+            >>> artifact.to_dict()
+            {
+                "name": "my_func",
+                "type": "function",
+                "start_line": 1,
+                "end_line": 5,
+                "language": "python",
+                "content": "def my_func(): ...",
+                "file_path": "src/module.py"
+            }
+        """
+        return dataclasses.asdict(self)

--- a/src/tokemize/repository_parser.py
+++ b/src/tokemize/repository_parser.py
@@ -1,0 +1,20 @@
+"""Ponto de entrada público do parser de repositório do Tokemize.
+
+Re-exporta RepositoryParser, RepositoryParseResult e parse_repository
+do módulo interno.
+
+Uso:
+    from tokemize.repository_parser import parse_repository, RepositoryParser
+"""
+
+from tokemize.core.parser.repository_parser import (  # noqa: F401
+    RepositoryParseResult,
+    RepositoryParser,
+    parse_repository,
+)
+
+__all__ = [
+    "RepositoryParser",
+    "RepositoryParseResult",
+    "parse_repository",
+]

--- a/src/tokemize/scanner.py
+++ b/src/tokemize/scanner.py
@@ -1,0 +1,27 @@
+"""Ponto de entrada público do scanner do Tokemize.
+
+Re-exporta RepositoryScanner, FileMetadata e ScanResult do módulo interno
+para satisfazer o entregável src/tokemize/scanner.py e manter a estrutura
+de pacotes em core/parser/.
+
+Uso:
+    from tokemize.scanner import RepositoryScanner, FileMetadata, ScanResult
+"""
+
+from tokemize.core.parser.scanner import (  # noqa: F401
+    DEFAULT_IGNORE_DIRS,
+    EXTENSION_TO_LANGUAGE,
+    SUPPORTED_EXTENSIONS,
+    FileMetadata,
+    RepositoryScanner,
+    ScanResult,
+)
+
+__all__ = [
+    "RepositoryScanner",
+    "FileMetadata",
+    "ScanResult",
+    "DEFAULT_IGNORE_DIRS",
+    "SUPPORTED_EXTENSIONS",
+    "EXTENSION_TO_LANGUAGE",
+]

--- a/src/tokemize/tree_sitter_analyzer.py
+++ b/src/tokemize/tree_sitter_analyzer.py
@@ -1,0 +1,25 @@
+"""Ponto de entrada público do analisador Tree-sitter do Tokemize.
+
+Re-exporta TreeSitterAnalyzer, UnsupportedLanguageError, ParseError e
+SUPPORTED_LANGUAGES do módulo interno para satisfazer o entregável
+src/tokemize/tree_sitter_analyzer.py e manter a estrutura de pacotes
+em core/parser/.
+
+Uso:
+    from tokemize.tree_sitter_analyzer import TreeSitterAnalyzer
+    from tokemize.tree_sitter_analyzer import UnsupportedLanguageError
+"""
+
+from tokemize.core.parser.tree_sitter_analyzer import (  # noqa: F401
+    ParseError,
+    SUPPORTED_LANGUAGES,
+    TreeSitterAnalyzer,
+    UnsupportedLanguageError,
+)
+
+__all__ = [
+    "TreeSitterAnalyzer",
+    "UnsupportedLanguageError",
+    "ParseError",
+    "SUPPORTED_LANGUAGES",
+]

--- a/tests/test_repository_parser.py
+++ b/tests/test_repository_parser.py
@@ -1,0 +1,534 @@
+"""Testes de integração: Scanner + TreeSitterAnalyzer via RepositoryParser.
+
+Valida o fluxo completo:
+    RepositoryScanner → [FileMetadata] → TreeSitterAnalyzer → [Artifact]
+
+Cobre:
+- parse() retorna RepositoryParseResult com arquivos e artefatos
+- Artefatos têm file_path rastreável ao FileMetadata do scanner
+- Diretórios ignorados pelo scanner não geram artefatos
+- Múltiplas linguagens no mesmo repositório
+- Repositório vazio ou sem arquivos suportados
+- Arquivos com erro de sintaxe não interrompem o pipeline
+- parse_streaming() gera os mesmos artefatos que parse()
+- parse_repository() (função de conveniência) funciona corretamente
+- Métricas de execução (elapsed_seconds, total_artifacts, etc.)
+- Agrupamentos: by_file, by_type, by_language
+- summary() retorna string legível
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from tokemize.core.parser.repository_parser import (
+    RepositoryParseResult,
+    RepositoryParser,
+    parse_repository,
+)
+from tokemize.core.parser.scanner import RepositoryScanner
+from tokemize.core.parser.tree_sitter_analyzer import TreeSitterAnalyzer
+from tokemize.models.artifact import Artifact
+
+
+# ---------------------------------------------------------------------------
+# Fixtures — repositório fake multi-linguagem
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def repo(tmp_path: Path) -> Path:
+    """Repositório fake com arquivos Python, Java, JS, TS e dirs ignorados.
+
+    Estrutura:
+        repo/
+        ├── main.py           → function: main, import: os
+        ├── utils.py          → function: helper, class: Config
+        ├── Service.java      → class: Service, method: execute, import: java.util.List
+        ├── app.js            → function: init, class: App, method: run
+        ├── types.ts          → interface: IUser (→ class), function: createUser
+        ├── README.md         → ignorado (extensão)
+        ├── .git/
+        │   └── config        → ignorado (dir)
+        ├── node_modules/
+        │   └── lib.js        → ignorado (dir)
+        └── src/
+            └── parser.py     → function: parse, class: Parser, method: run
+    """
+    root = tmp_path / "repo"
+    root.mkdir()
+
+    (root / "main.py").write_text(
+        "import os\n\ndef main():\n    pass\n",
+        encoding="utf-8",
+    )
+    (root / "utils.py").write_text(
+        "class Config:\n    def load(self):\n        pass\n\ndef helper():\n    return 42\n",
+        encoding="utf-8",
+    )
+    (root / "Service.java").write_text(
+        "import java.util.List;\npublic class Service {\n    public void execute() {}\n}\n",
+        encoding="utf-8",
+    )
+    (root / "app.js").write_text(
+        "class App {\n    run() {}\n}\nfunction init() {}\n",
+        encoding="utf-8",
+    )
+    (root / "types.ts").write_text(
+        "interface IUser { name: string; }\nfunction createUser(name: string): IUser { return { name }; }\n",
+        encoding="utf-8",
+    )
+    (root / "README.md").write_text("# Docs\n", encoding="utf-8")
+
+    # Dirs ignorados
+    git_dir = root / ".git"
+    git_dir.mkdir()
+    (git_dir / "config").write_text("[core]\n")
+
+    nm_dir = root / "node_modules"
+    nm_dir.mkdir()
+    (nm_dir / "lib.js").write_text("module.exports = {};\n")
+
+    # Subdiretório válido
+    src_dir = root / "src"
+    src_dir.mkdir()
+    (src_dir / "parser.py").write_text(
+        "class Parser:\n    def run(self):\n        pass\n\ndef parse():\n    pass\n",
+        encoding="utf-8",
+    )
+
+    return root
+
+
+@pytest.fixture()
+def parser() -> RepositoryParser:
+    """RepositoryParser com configuração padrão."""
+    return RepositoryParser()
+
+
+# ---------------------------------------------------------------------------
+# Testes do resultado básico
+# ---------------------------------------------------------------------------
+
+class TestRepositoryParserBasic:
+    """Testes do fluxo básico de parse."""
+
+    def test_parse_returns_repository_parse_result(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """parse() deve retornar uma instância de RepositoryParseResult."""
+        result = parser.parse(repo)
+        assert isinstance(result, RepositoryParseResult)
+
+    def test_parse_root_is_set(self, parser: RepositoryParser, repo: Path) -> None:
+        """RepositoryParseResult.root deve ser o diretório analisado."""
+        result = parser.parse(repo)
+        assert result.root == repo.resolve()
+
+    def test_parse_finds_all_valid_files(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """parse() deve encontrar todos os arquivos com extensão suportada."""
+        result = parser.parse(repo)
+        names = {f.relative_path.name for f in result.files}
+        assert names == {
+            "main.py", "utils.py", "Service.java",
+            "app.js", "types.ts", "parser.py",
+        }
+
+    def test_parse_total_files_matches_files_list(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """total_files deve ser igual ao tamanho da lista files."""
+        result = parser.parse(repo)
+        assert result.total_files == len(result.files)
+
+    def test_parse_extracts_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """parse() deve extrair pelo menos um artefato por arquivo válido."""
+        result = parser.parse(repo)
+        assert result.total_artifacts > 0
+        assert result.total_artifacts == len(result.artifacts)
+
+    def test_parse_elapsed_seconds_positive(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """elapsed_seconds deve ser maior que zero."""
+        result = parser.parse(repo)
+        assert result.elapsed_seconds > 0
+
+    def test_parse_invalid_directory_raises(
+        self, parser: RepositoryParser, tmp_path: Path
+    ) -> None:
+        """parse() deve levantar NotADirectoryError para caminho inválido."""
+        with pytest.raises(NotADirectoryError):
+            parser.parse(tmp_path / "nao_existe")
+
+
+# ---------------------------------------------------------------------------
+# Testes de rastreabilidade Scanner → Analyzer
+# ---------------------------------------------------------------------------
+
+class TestTracability:
+    """Testa que artefatos são rastreáveis aos arquivos do scanner."""
+
+    def test_artifact_file_path_matches_scanner_file(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """file_path de cada artefato deve corresponder a um arquivo do scanner."""
+        result = parser.parse(repo)
+        scanner_paths = {str(f.path) for f in result.files}
+        for artifact in result.artifacts:
+            assert artifact.file_path in scanner_paths, (
+                f"Artefato '{artifact.name}' tem file_path '{artifact.file_path}' "
+                f"que não está na lista do scanner"
+            )
+
+    def test_every_file_has_at_least_one_artifact(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Cada arquivo encontrado pelo scanner deve ter pelo menos 1 artefato."""
+        result = parser.parse(repo)
+        files_with_artifacts = {a.file_path for a in result.artifacts}
+        for file_meta in result.files:
+            assert str(file_meta.path) in files_with_artifacts, (
+                f"Arquivo '{file_meta.relative_path}' não gerou nenhum artefato"
+            )
+
+    def test_ignored_dirs_produce_no_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Arquivos em diretórios ignorados não devem gerar artefatos."""
+        result = parser.parse(repo)
+        for artifact in result.artifacts:
+            assert "node_modules" not in artifact.file_path
+            assert ".git" not in artifact.file_path
+
+    def test_artifact_language_matches_file_extension(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Linguagem do artefato deve corresponder à extensão do arquivo."""
+        ext_to_lang = {".py": "python", ".java": "java", ".js": "javascript", ".ts": "typescript"}
+        result = parser.parse(repo)
+        for artifact in result.artifacts:
+            ext = Path(artifact.file_path).suffix.lower()
+            expected_lang = ext_to_lang.get(ext)
+            if expected_lang:
+                assert artifact.language == expected_lang, (
+                    f"Artefato '{artifact.name}' tem language='{artifact.language}' "
+                    f"mas extensão '{ext}' esperava '{expected_lang}'"
+                )
+
+
+# ---------------------------------------------------------------------------
+# Testes de extração por linguagem
+# ---------------------------------------------------------------------------
+
+class TestMultiLanguageExtraction:
+    """Testa extração de artefatos em múltiplas linguagens no mesmo repositório."""
+
+    def test_extracts_python_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Deve extrair artefatos Python do repositório."""
+        result = parser.parse(repo)
+        py_artifacts = [a for a in result.artifacts if a.language == "python"]
+        names = {a.name for a in py_artifacts}
+        assert "main" in names
+        assert "helper" in names
+        assert "Config" in names
+        assert "Parser" in names
+
+    def test_extracts_java_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Deve extrair artefatos Java do repositório."""
+        result = parser.parse(repo)
+        java_artifacts = [a for a in result.artifacts if a.language == "java"]
+        names = {a.name for a in java_artifacts}
+        assert "Service" in names
+        assert "execute" in names
+
+    def test_extracts_javascript_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Deve extrair artefatos JavaScript do repositório."""
+        result = parser.parse(repo)
+        js_artifacts = [a for a in result.artifacts if a.language == "javascript"]
+        names = {a.name for a in js_artifacts}
+        assert "App" in names
+        assert "init" in names
+
+    def test_extracts_typescript_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Deve extrair artefatos TypeScript do repositório."""
+        result = parser.parse(repo)
+        ts_artifacts = [a for a in result.artifacts if a.language == "typescript"]
+        names = {a.name for a in ts_artifacts}
+        assert "IUser" in names
+        assert "createUser" in names
+
+    def test_all_four_languages_represented(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Todas as quatro linguagens devem estar representadas nos artefatos."""
+        result = parser.parse(repo)
+        languages = {a.language for a in result.artifacts}
+        assert languages == {"python", "java", "javascript", "typescript"}
+
+
+# ---------------------------------------------------------------------------
+# Testes de agrupamento
+# ---------------------------------------------------------------------------
+
+class TestGrouping:
+    """Testa os métodos de agrupamento do RepositoryParseResult."""
+
+    def test_artifacts_by_file_keys_are_file_paths(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """artifacts_by_file() deve ter como chaves os caminhos dos arquivos."""
+        result = parser.parse(repo)
+        by_file = result.artifacts_by_file()
+        scanner_paths = {str(f.path) for f in result.files}
+        for key in by_file:
+            assert key in scanner_paths
+
+    def test_artifacts_by_file_all_artifacts_present(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """artifacts_by_file() deve conter todos os artefatos sem perda."""
+        result = parser.parse(repo)
+        by_file = result.artifacts_by_file()
+        total = sum(len(v) for v in by_file.values())
+        assert total == result.total_artifacts
+
+    def test_artifacts_by_type_valid_keys(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """artifacts_by_type() deve ter apenas tipos válidos como chaves."""
+        result = parser.parse(repo)
+        valid_types = {"function", "class", "method", "import"}
+        for key in result.artifacts_by_type():
+            assert key in valid_types
+
+    def test_artifacts_by_type_all_artifacts_present(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """artifacts_by_type() deve conter todos os artefatos sem perda."""
+        result = parser.parse(repo)
+        total = sum(len(v) for v in result.artifacts_by_type().values())
+        assert total == result.total_artifacts
+
+    def test_artifacts_by_language_all_artifacts_present(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """artifacts_by_language() deve conter todos os artefatos sem perda."""
+        result = parser.parse(repo)
+        total = sum(len(v) for v in result.artifacts_by_language().values())
+        assert total == result.total_artifacts
+
+    def test_summary_contains_key_metrics(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """summary() deve conter as métricas principais."""
+        result = parser.parse(repo)
+        summary = result.summary()
+        assert str(result.total_files) in summary
+        assert str(result.total_artifacts) in summary
+        assert "python" in summary.lower()
+
+
+# ---------------------------------------------------------------------------
+# Testes de resiliência
+# ---------------------------------------------------------------------------
+
+class TestResilience:
+    """Testa comportamento do pipeline em situações adversas."""
+
+    def test_syntax_error_file_does_not_stop_pipeline(
+        self, tmp_path: Path
+    ) -> None:
+        """Arquivo com erro de sintaxe não deve interromper a análise dos demais."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "valid.py").write_text("def ok(): pass\n", encoding="utf-8")
+        (root / "broken.py").write_text("def broken(\n", encoding="utf-8")
+
+        result = RepositoryParser().parse(root)
+        names = {a.name for a in result.artifacts}
+        assert "ok" in names
+        # broken.py pode gerar 0 artefatos mas não deve quebrar
+        assert result.failed_files == 0  # erro de sintaxe parcial não é falha
+
+    def test_empty_repository_returns_empty_result(self, tmp_path: Path) -> None:
+        """Repositório sem arquivos suportados deve retornar resultado vazio."""
+        root = tmp_path / "empty"
+        root.mkdir()
+        (root / "README.md").write_text("# Docs\n")
+
+        result = RepositoryParser().parse(root)
+        assert result.total_files == 0
+        assert result.total_artifacts == 0
+        assert result.artifacts == []
+
+    def test_repository_with_only_ignored_dirs(self, tmp_path: Path) -> None:
+        """Repositório com apenas dirs ignorados deve retornar resultado vazio."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        nm = root / "node_modules"
+        nm.mkdir()
+        (nm / "lib.js").write_text("module.exports = {};\n")
+
+        result = RepositoryParser().parse(root)
+        assert result.total_files == 0
+        assert result.total_artifacts == 0
+
+    def test_custom_ignore_dirs_respected(self, tmp_path: Path) -> None:
+        """Diretórios customizados ignorados não devem gerar artefatos."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "main.py").write_text("def main(): pass\n")
+        vendor = root / "vendor"
+        vendor.mkdir()
+        (vendor / "lib.py").write_text("def vendor_func(): pass\n")
+
+        scanner = RepositoryScanner(ignore_dirs={"vendor"})
+        result = RepositoryParser(scanner=scanner).parse(root)
+        names = {a.name for a in result.artifacts}
+        assert "main" in names
+        assert "vendor_func" not in names
+
+
+# ---------------------------------------------------------------------------
+# Testes do parse_streaming()
+# ---------------------------------------------------------------------------
+
+class TestStreaming:
+    """Testa o modo streaming do RepositoryParser."""
+
+    def test_streaming_yields_artifacts(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """parse_streaming() deve gerar instâncias de Artifact."""
+        artifacts = list(parser.parse_streaming(repo))
+        assert len(artifacts) > 0
+        assert all(isinstance(a, Artifact) for a in artifacts)
+
+    def test_streaming_same_artifacts_as_parse(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """parse_streaming() deve gerar os mesmos artefatos que parse()."""
+        batch_names = {a.name for a in parser.parse(repo).artifacts}
+        stream_names = {a.name for a in parser.parse_streaming(repo)}
+        assert batch_names == stream_names
+
+    def test_streaming_respects_ignore_dirs(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """parse_streaming() não deve gerar artefatos de dirs ignorados."""
+        for artifact in parser.parse_streaming(repo):
+            assert "node_modules" not in artifact.file_path
+            assert ".git" not in artifact.file_path
+
+    def test_streaming_invalid_directory_raises(
+        self, parser: RepositoryParser, tmp_path: Path
+    ) -> None:
+        """parse_streaming() deve levantar NotADirectoryError para caminho inválido."""
+        with pytest.raises(NotADirectoryError):
+            list(parser.parse_streaming(tmp_path / "nao_existe"))
+
+
+# ---------------------------------------------------------------------------
+# Testes da função de conveniência parse_repository()
+# ---------------------------------------------------------------------------
+
+class TestParseRepositoryFunction:
+    """Testa a função de conveniência parse_repository()."""
+
+    def test_parse_repository_returns_result(self, repo: Path) -> None:
+        """parse_repository() deve retornar RepositoryParseResult."""
+        result = parse_repository(repo)
+        assert isinstance(result, RepositoryParseResult)
+
+    def test_parse_repository_extracts_artifacts(self, repo: Path) -> None:
+        """parse_repository() deve extrair artefatos do repositório."""
+        result = parse_repository(repo)
+        assert result.total_artifacts > 0
+
+    def test_parse_repository_custom_ignore_dirs(self, tmp_path: Path) -> None:
+        """parse_repository() deve respeitar ignore_dirs customizados."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "main.py").write_text("def main(): pass\n")
+        custom = root / "custom_ignore"
+        custom.mkdir()
+        (custom / "hidden.py").write_text("def hidden(): pass\n")
+
+        result = parse_repository(root, ignore_dirs={"custom_ignore"})
+        names = {a.name for a in result.artifacts}
+        assert "main" in names
+        assert "hidden" not in names
+
+    def test_parse_repository_public_import(self, repo: Path) -> None:
+        """parse_repository deve ser importável via tokemize.repository_parser."""
+        from tokemize.repository_parser import parse_repository as pr  # noqa: PLC0415
+        result = pr(repo)
+        assert result.total_artifacts > 0
+
+
+# ---------------------------------------------------------------------------
+# Testes de invariantes dos artefatos no pipeline completo
+# ---------------------------------------------------------------------------
+
+class TestArtifactInvariantsIntegration:
+    """Valida invariantes dos artefatos produzidos pelo pipeline completo."""
+
+    def test_all_artifacts_have_valid_type(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Todos os artefatos do pipeline devem ter type válido."""
+        valid_types = {"function", "class", "method", "import"}
+        result = parser.parse(repo)
+        for a in result.artifacts:
+            assert a.type in valid_types, f"type inválido: {a.type} em {a.name}"
+
+    def test_all_artifacts_have_non_empty_name(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Todos os artefatos devem ter name não vazio."""
+        result = parser.parse(repo)
+        for a in result.artifacts:
+            assert a.name.strip() != "", f"name vazio em {a}"
+
+    def test_all_artifacts_have_valid_line_range(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Todos os artefatos devem ter start_line <= end_line."""
+        result = parser.parse(repo)
+        for a in result.artifacts:
+            assert a.start_line <= a.end_line, (
+                f"Invariante violada: start={a.start_line} > end={a.end_line} em {a.name}"
+            )
+
+    def test_all_artifacts_have_non_empty_content(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Todos os artefatos devem ter content não vazio."""
+        result = parser.parse(repo)
+        for a in result.artifacts:
+            assert a.content.strip() != "", f"content vazio em {a.name}"
+
+    def test_all_artifacts_are_json_serializable(
+        self, parser: RepositoryParser, repo: Path
+    ) -> None:
+        """Todos os artefatos do pipeline devem ser serializáveis em JSON."""
+        import json  # noqa: PLC0415
+        result = parser.parse(repo)
+        for a in result.artifacts:
+            d = a.to_dict()
+            json_str = json.dumps(d)
+            assert isinstance(json_str, str)

--- a/tests/test_scanner.py
+++ b/tests/test_scanner.py
@@ -249,6 +249,22 @@ class TestFileMetadata:
         assert len(result.files) == 1
         assert result.files[0].line_count == 3
 
+    def test_metadata_char_count_positive(self, scanner: RepositoryScanner, repo: Path) -> None:
+        """char_count deve ser maior que zero para arquivos não vazios."""
+        result = scanner.scan(repo)
+        assert all(f.char_count > 0 for f in result.files)
+
+    def test_metadata_char_count_accuracy(self, tmp_path: Path) -> None:
+        """char_count deve refletir o número real de caracteres do arquivo."""
+        root = tmp_path / "proj"
+        root.mkdir()
+        content = "abc\ndef\n"  # 8 caracteres
+        (root / "test.py").write_text(content, encoding="utf-8")
+
+        result = RepositoryScanner().scan(root)
+        assert len(result.files) == 1
+        assert result.files[0].char_count == len(content)
+
     def test_metadata_relative_path_is_not_absolute(self, scanner: RepositoryScanner, repo: Path) -> None:
         """relative_path deve ser relativo à raiz do repositório."""
         result = scanner.scan(repo)
@@ -537,3 +553,29 @@ class TestEmptyDirectory:
         (root / "config.yaml").write_text("key: value\n")
         result = RepositoryScanner().scan(root)
         assert result.total_files == 0
+
+
+# ---------------------------------------------------------------------------
+# Teste de import público — src/tokemize/scanner.py
+# ---------------------------------------------------------------------------
+
+
+class TestPublicImport:
+    """Garante que o entregável src/tokemize/scanner.py está acessível."""
+
+    def test_import_from_tokemize_scanner(self) -> None:
+        """RepositoryScanner deve ser importável via tokemize.scanner."""
+        from tokemize.scanner import RepositoryScanner as RS  # noqa: PLC0415
+        assert RS is RepositoryScanner
+
+    def test_scanner_via_public_module(self, tmp_path: Path) -> None:
+        """Scanner importado via tokemize.scanner deve funcionar normalmente."""
+        from tokemize.scanner import RepositoryScanner as RS  # noqa: PLC0415
+
+        root = tmp_path / "proj"
+        root.mkdir()
+        (root / "main.py").write_text("def main(): pass\n")
+
+        result = RS().scan(root)
+        assert result.total_files == 1
+        assert result.files[0].char_count > 0

--- a/tests/test_tree_sitter_analyzer.py
+++ b/tests/test_tree_sitter_analyzer.py
@@ -580,3 +580,89 @@ class TestArtifactModel:
         assert a.name == "my_func"
         assert a.type == "function"
         assert a.file_path == ""  # default
+
+
+# ---------------------------------------------------------------------------
+# Teste de import público — src/tokemize/tree_sitter_analyzer.py
+# ---------------------------------------------------------------------------
+
+
+class TestPublicImport:
+    """Garante que o entregável src/tokemize/tree_sitter_analyzer.py está acessível."""
+
+    def test_import_from_tokemize_tree_sitter_analyzer(self) -> None:
+        """TreeSitterAnalyzer deve ser importável via tokemize.tree_sitter_analyzer."""
+        from tokemize.tree_sitter_analyzer import TreeSitterAnalyzer as TSA  # noqa: PLC0415
+        assert TSA is TreeSitterAnalyzer
+
+    def test_unsupported_language_error_importable(self) -> None:
+        """UnsupportedLanguageError deve ser importável via tokemize.tree_sitter_analyzer."""
+        from tokemize.tree_sitter_analyzer import UnsupportedLanguageError as ULE  # noqa: PLC0415
+        assert ULE is UnsupportedLanguageError
+
+    def test_analyzer_via_public_module(self, tmp_path: Path) -> None:
+        """Analyzer importado via tokemize.tree_sitter_analyzer deve funcionar normalmente."""
+        from tokemize.tree_sitter_analyzer import TreeSitterAnalyzer as TSA  # noqa: PLC0415
+
+        f = _write(tmp_path, "main.py", "def hello(): pass\n")
+        artifacts = TSA().analyze(f)
+        assert len(artifacts) == 1
+        assert artifacts[0].name == "hello"
+
+
+# ---------------------------------------------------------------------------
+# Critério 7 — resultado consumível pelo próximo módulo
+# ---------------------------------------------------------------------------
+
+
+class TestConsumableResult:
+    """Garante que os artefatos podem ser consumidos pelo próximo módulo (Indexer)."""
+
+    def test_artifact_has_to_dict(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Artifact deve expor to_dict() para integração com módulos downstream."""
+        f = _write(tmp_path, "mod.py", "def foo(): pass\n")
+        artifacts = analyzer.analyze(f)
+        assert len(artifacts) == 1
+        d = artifacts[0].to_dict()
+        assert isinstance(d, dict)
+
+    def test_to_dict_contains_all_fields(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """to_dict() deve conter todos os campos necessários para o próximo módulo."""
+        f = _write(tmp_path, "mod.py", "def foo(): pass\n")
+        artifact = analyzer.analyze(f)[0]
+        d = artifact.to_dict()
+        required_keys = {"name", "type", "start_line", "end_line", "language", "content", "file_path"}
+        assert required_keys == set(d.keys())
+
+    def test_to_dict_is_json_serializable(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """to_dict() deve produzir um dicionário serializável em JSON."""
+        import json  # noqa: PLC0415
+        f = _write(tmp_path, "mod.py", "def foo(): pass\n")
+        artifact = analyzer.analyze(f)[0]
+        json_str = json.dumps(artifact.to_dict())
+        assert isinstance(json_str, str)
+        restored = json.loads(json_str)
+        assert restored["name"] == artifact.name
+        assert restored["type"] == artifact.type
+
+    def test_analyze_many_result_all_consumable(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Todos os artefatos de analyze_many() devem ser consumíveis via to_dict()."""
+        f1 = _write(tmp_path, "a.py", "def func_a(): pass\n")
+        f2 = _write(tmp_path, "b.py", "class ClassB: pass\n")
+        artifacts = analyzer.analyze_many([f1, f2])
+        for a in artifacts:
+            d = a.to_dict()
+            assert d["name"] in ("func_a", "ClassB")
+            assert d["language"] == "python"
+
+    def test_unsupported_file_ignored_safely(self, analyzer: TreeSitterAnalyzer, tmp_path: Path) -> None:
+        """Arquivo não suportado em analyze_many() não deve quebrar e retorna lista válida."""
+        py_file = _write(tmp_path, "valid.py", "def ok(): pass\n")
+        rb_file = _write(tmp_path, "invalid.rb", "puts 'hi'\n")
+        xml_file = _write(tmp_path, "data.xml", "<root/>\n")
+
+        artifacts = analyzer.analyze_many([py_file, rb_file, xml_file])
+        assert len(artifacts) == 1
+        assert artifacts[0].name == "ok"
+        # Resultado é consumível normalmente
+        assert artifacts[0].to_dict()["type"] == "function"


### PR DESCRIPTION
## O que foi feito?

#scanner.py:

- Adiciona campo char_count em FileMetadata para contar caracteres UTF-8
- Adiciona metodo _count_chars() para leitura do conteudo do arquivo
- Cria src/tokemize/scanner.py como modulo publico (re-exporta RepositoryScanner, FileMetadata, ScanResult e constantes)

tree_sitter_analyzer.py:

- Cria src/tokemize/tree_sitter_analyzer.py como modulo publico  (re-exporta TreeSitterAnalyzer, UnsupportedLanguageError, ParseError)

#artifact.py:

- Adiciona metodo to_dict() para serializacao JSON do artefato, permitindo consumo direto pelo modulo Indexer downstream

#tests:

- Adiciona TestPublicImport no scanner: valida import via tokemize.scanner
- Adiciona TestPublicImport no analyzer: valida import via tokemize.tree_sitter_analyzer
- Adiciona TestConsumableResult: 5 testes validando to_dict(), serializacao JSON e seguranca com arquivos nao suportados
- Adiciona test_metadata_char_count_positive e test_metadata_char_count_accuracy para o novo campo char_count
- Total: 116 testes passando (2 skipped no Windows por symlinks)"


## Tipo de mudança
- [x ] feature
- [ ] fix
- [ ] docs
- [ ] refactor
- [ ] hotfix

## Checklist
- [x] A branch segue o padrão correto
- [x] O PR está apontando para a branch correta
- [x] Testes foram executados
- [x] Não há arquivos desnecessários