### PR TITLE
feat(summarizer): módulo Summarizer com cache e fallback de LLM

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
 dev = [
     "pytest==8.3.5",
     "pytest-cov==6.1.0",
+    "hypothesis>=6.100.0",
 ]
 
 [tool.setuptools.packages.find]

--- a/src/tokemize/integrations/__init__.py
+++ b/src/tokemize/integrations/__init__.py
@@ -1,0 +1,1 @@
+"""Integrações externas do Tokemize (LLMs, embeddings, etc.)."""

--- a/src/tokemize/integrations/llm/__init__.py
+++ b/src/tokemize/integrations/llm/__init__.py
@@ -1,0 +1,7 @@
+"""Clientes de LLM para integração com provedores externos."""
+
+from tokemize.integrations.llm.protocol import LLMClientProtocol
+from tokemize.integrations.llm.openai_client import OpenAIClient
+from tokemize.integrations.llm.anthropic_client import AnthropicClient
+
+__all__ = ["LLMClientProtocol", "OpenAIClient", "AnthropicClient"]

--- a/src/tokemize/integrations/llm/anthropic_client.py
+++ b/src/tokemize/integrations/llm/anthropic_client.py
@@ -1,0 +1,84 @@
+"""Cliente de LLM para a API Anthropic."""
+
+import logging
+import os
+
+import anthropic
+from dotenv import load_dotenv
+
+logger = logging.getLogger(__name__)
+
+_ENV_VAR = "ANTHROPIC_API_KEY"
+_DEFAULT_MODEL = "claude-sonnet-4-5"
+_MAX_TOKENS = 1024
+
+
+class AnthropicClient:
+    """Cliente concreto para a API Anthropic (Claude).
+
+    Carrega a chave de API exclusivamente via variável de ambiente
+    ``ANTHROPIC_API_KEY``, utilizando ``python-dotenv`` para leitura do
+    arquivo ``.env``. Nunca registra o valor da chave em logs.
+
+    Args:
+        model: Identificador do modelo Anthropic a ser utilizado.
+            Padrão: ``"claude-sonnet-4-5"``.
+        max_tokens: Número máximo de tokens na resposta. Padrão: ``1024``.
+
+    Raises:
+        EnvironmentError: Se a variável de ambiente ``ANTHROPIC_API_KEY``
+            não estiver definida.
+
+    Example:
+        >>> client = AnthropicClient()
+        >>> summary = client.complete("Resuma este arquivo...")
+    """
+
+    def __init__(
+        self,
+        model: str = _DEFAULT_MODEL,
+        max_tokens: int = _MAX_TOKENS,
+    ) -> None:
+        """Inicializa o cliente Anthropic carregando a API key do ambiente.
+
+        Args:
+            model: Identificador do modelo Anthropic a ser utilizado.
+            max_tokens: Número máximo de tokens na resposta.
+
+        Raises:
+            EnvironmentError: Se ``ANTHROPIC_API_KEY`` não estiver definida
+                no ambiente ou no arquivo ``.env``.
+        """
+        load_dotenv()
+        api_key = os.getenv(_ENV_VAR)
+        if not api_key:
+            raise EnvironmentError(
+                f"Variável de ambiente '{_ENV_VAR}' não está definida. "
+                "Defina-a no arquivo .env ou no ambiente do sistema."
+            )
+        self._model = model
+        self._max_tokens = max_tokens
+        self._client = anthropic.Anthropic(api_key=api_key)
+        logger.debug("AnthropicClient inicializado com modelo '%s'", model)
+
+    def complete(self, prompt: str) -> str:
+        """Envia um prompt ao modelo Anthropic e retorna a resposta.
+
+        Args:
+            prompt: Texto do prompt a ser enviado ao modelo.
+
+        Returns:
+            Resposta gerada pelo modelo como string.
+
+        Raises:
+            anthropic.APIError: Em caso de falha na comunicação com a API.
+        """
+        logger.debug("Enviando prompt ao Anthropic (modelo=%s)", self._model)
+        message = self._client.messages.create(
+            model=self._model,
+            max_tokens=self._max_tokens,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        result: str = message.content[0].text if message.content else ""
+        logger.debug("Resposta recebida do Anthropic (%d chars)", len(result))
+        return result

--- a/src/tokemize/integrations/llm/openai_client.py
+++ b/src/tokemize/integrations/llm/openai_client.py
@@ -1,0 +1,75 @@
+"""Cliente de LLM para a API OpenAI."""
+
+import logging
+import os
+
+from dotenv import load_dotenv
+from openai import OpenAI
+
+logger = logging.getLogger(__name__)
+
+_ENV_VAR = "OPENAI_API_KEY"
+_DEFAULT_MODEL = "gpt-4o"
+
+
+class OpenAIClient:
+    """Cliente concreto para a API OpenAI (GPT-4o).
+
+    Carrega a chave de API exclusivamente via variável de ambiente
+    ``OPENAI_API_KEY``, utilizando ``python-dotenv`` para leitura do
+    arquivo ``.env``. Nunca registra o valor da chave em logs.
+
+    Args:
+        model: Identificador do modelo OpenAI a ser utilizado.
+            Padrão: ``"gpt-4o"``.
+
+    Raises:
+        EnvironmentError: Se a variável de ambiente ``OPENAI_API_KEY``
+            não estiver definida.
+
+    Example:
+        >>> client = OpenAIClient()
+        >>> summary = client.complete("Resuma este arquivo...")
+    """
+
+    def __init__(self, model: str = _DEFAULT_MODEL) -> None:
+        """Inicializa o cliente OpenAI carregando a API key do ambiente.
+
+        Args:
+            model: Identificador do modelo OpenAI a ser utilizado.
+
+        Raises:
+            EnvironmentError: Se ``OPENAI_API_KEY`` não estiver definida
+                no ambiente ou no arquivo ``.env``.
+        """
+        load_dotenv()
+        api_key = os.getenv(_ENV_VAR)
+        if not api_key:
+            raise EnvironmentError(
+                f"Variável de ambiente '{_ENV_VAR}' não está definida. "
+                "Defina-a no arquivo .env ou no ambiente do sistema."
+            )
+        self._model = model
+        self._client = OpenAI(api_key=api_key)
+        logger.debug("OpenAIClient inicializado com modelo '%s'", model)
+
+    def complete(self, prompt: str) -> str:
+        """Envia um prompt ao modelo OpenAI e retorna a resposta.
+
+        Args:
+            prompt: Texto do prompt a ser enviado ao modelo.
+
+        Returns:
+            Resposta gerada pelo modelo como string.
+
+        Raises:
+            openai.OpenAIError: Em caso de falha na comunicação com a API.
+        """
+        logger.debug("Enviando prompt ao OpenAI (modelo=%s)", self._model)
+        response = self._client.chat.completions.create(
+            model=self._model,
+            messages=[{"role": "user", "content": prompt}],
+        )
+        result: str = response.choices[0].message.content or ""
+        logger.debug("Resposta recebida do OpenAI (%d chars)", len(result))
+        return result

--- a/src/tokemize/integrations/llm/protocol.py
+++ b/src/tokemize/integrations/llm/protocol.py
@@ -1,0 +1,36 @@
+"""Protocolo de interface para clientes de LLM."""
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMClientProtocol(Protocol):
+    """Protocolo abstrato para clientes de LLM.
+
+    Define a interface mínima que qualquer cliente de LLM deve implementar
+    para ser compatível com o pipeline Tokemize. Implementações concretas
+    residem em módulos específicos deste pacote (ex: openai_client.py,
+    anthropic_client.py).
+
+    Example:
+        >>> class MyLLMClient:
+        ...     def complete(self, prompt: str) -> str:
+        ...         return "resposta do LLM"
+        >>> isinstance(MyLLMClient(), LLMClientProtocol)
+        True
+    """
+
+    def complete(self, prompt: str) -> str:
+        """Envia um prompt ao LLM e retorna a resposta como string.
+
+        Args:
+            prompt: Texto do prompt a ser enviado ao modelo.
+
+        Returns:
+            Resposta gerada pelo modelo como string.
+
+        Raises:
+            Exception: Qualquer exceção de comunicação ou autenticação
+                lançada pelo provedor de LLM.
+        """
+        ...

--- a/src/tokemize/summarizer.py
+++ b/src/tokemize/summarizer.py
@@ -1,0 +1,141 @@
+"""Módulo responsável por resumir arquivos relevantes usando LLM."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+
+from tokemize.cache import FileCache
+from tokemize.integrations.llm.protocol import LLMClientProtocol
+
+logger = logging.getLogger(__name__)
+
+FALLBACK_MESSAGE: str = "[Resumo indisponível: falha ao contatar o serviço de LLM]"
+
+SUMMARY_PROMPT_TEMPLATE: str = """\
+Você é um assistente técnico especializado em análise de código-fonte.
+Gere um resumo técnico compacto do arquivo abaixo.
+O resumo deve cobrir: propósito do arquivo, estruturas principais (classes, funções,
+tipos), dependências externas relevantes e padrões de design utilizados.
+Seja objetivo e conciso. Não inclua o código-fonte no resumo.
+
+Arquivo: {file_path}
+
+{content}
+"""
+
+
+class Summarizer:
+    """Gera e cacheia resumos técnicos de arquivos de código-fonte via LLM.
+
+    Recebe um caminho de arquivo e seu conteúdo, consulta o ``FileCache``
+    antes de chamar a API, e retorna sempre uma ``str`` — seja o resumo
+    gerado, o resumo cacheado, ou uma mensagem de fallback controlada em
+    caso de falha. O pipeline nunca é interrompido por falhas do LLM.
+
+    Args:
+        llm_client: Instância de um cliente de LLM compatível com
+            ``LLMClientProtocol``. Nunca instanciado internamente.
+        cache: Instância de ``FileCache`` para persistência de resumos.
+            Se ``None``, opera sem cache (chama o LLM a cada invocação).
+
+    Example:
+        >>> from unittest.mock import MagicMock
+        >>> mock_llm = MagicMock()
+        >>> mock_llm.complete.return_value = "Resumo do arquivo."
+        >>> summarizer = Summarizer(llm_client=mock_llm)
+        >>> summarizer.summarize("app.py", "def main(): pass")
+        'Resumo do arquivo.'
+    """
+
+    def __init__(
+        self,
+        llm_client: LLMClientProtocol,
+        cache: FileCache | None = None,
+    ) -> None:
+        """Inicializa o Summarizer com injeção de dependência.
+
+        Args:
+            llm_client: Cliente de LLM compatível com ``LLMClientProtocol``.
+            cache: Instância de ``FileCache`` para cache de resumos.
+                Opcional; se ``None``, o cache é desabilitado.
+        """
+        self._llm_client = llm_client
+        self._cache = cache
+        logger.debug(
+            "Summarizer inicializado (cache=%s)",
+            "habilitado" if cache is not None else "desabilitado",
+        )
+
+    def summarize(self, file_path: str | Path, content: str) -> str:
+        """Gera um resumo técnico compacto de um arquivo de código-fonte.
+
+        Consulta o cache antes de chamar o LLM. Em caso de falha da API,
+        retorna uma mensagem de fallback controlada sem propagar a exceção.
+
+        Args:
+            file_path: Caminho do arquivo a ser resumido (``str`` ou
+                ``pathlib.Path``).
+            content: Conteúdo textual do arquivo a ser resumido.
+
+        Returns:
+            Resumo técnico gerado pelo LLM, resumo cacheado (se válido),
+            string vazia (se ``content`` for vazio), ou
+            ``FALLBACK_MESSAGE`` em caso de falha da API.
+        """
+        path_str = str(file_path)
+        logger.info("Iniciando sumarização: '%s'", path_str)
+
+        if not content:
+            logger.debug("Conteúdo vazio para '%s', retornando string vazia", path_str)
+            return ""
+
+        # Verifica cache
+        if self._cache is not None:
+            cached_entry = self._cache.get_cached_file(file_path)
+            if cached_entry is not None:
+                cached_summary: str = cached_entry.get("summary", "")
+                if cached_summary:
+                    logger.info("Cache hit para '%s'", path_str)
+                    return cached_summary
+            logger.debug("Cache miss para '%s'", path_str)
+
+        # Chama o LLM
+        prompt = SUMMARY_PROMPT_TEMPLATE.format(
+            file_path=path_str,
+            content=content,
+        )
+
+        try:
+            summary = self._llm_client.complete(prompt)
+            logger.info(
+                "Resumo gerado para '%s' (%d chars)", path_str, len(summary)
+            )
+        except Exception as exc:
+            logger.error(
+                "Falha ao gerar resumo para '%s': %s",
+                path_str,
+                type(exc).__name__,
+            )
+            return FALLBACK_MESSAGE
+
+        # Persiste no cache
+        if self._cache is not None:
+            self._cache.update_cached_file(file_path, summary=summary)
+            self._cache.save_cache()
+            logger.debug("Resumo persistido no cache para '%s'", path_str)
+
+        return summary
+
+    @staticmethod
+    def _hash_content(content: str) -> str:
+        """Calcula o hash SHA-256 de um conteúdo textual.
+
+        Args:
+            content: Texto cujo hash será calculado.
+
+        Returns:
+            Hash SHA-256 em formato hexadecimal.
+        """
+        return hashlib.sha256(content.encode("utf-8")).hexdigest()

--- a/tests/test_summarizer.py
+++ b/tests/test_summarizer.py
@@ -1,0 +1,361 @@
+"""Testes unitários e baseados em propriedades para o módulo Summarizer."""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+from pathlib import Path
+from unittest.mock import MagicMock, call
+
+import pytest
+from hypothesis import given, settings
+from hypothesis import strategies as st
+
+from tokemize.cache import FileCache
+from tokemize.integrations.llm.protocol import LLMClientProtocol
+from tokemize.summarizer import FALLBACK_MESSAGE, Summarizer
+
+# ---------------------------------------------------------------------------
+# Estratégias Hypothesis reutilizáveis
+# ---------------------------------------------------------------------------
+
+file_path_strategy = st.one_of(
+    st.text(min_size=1, max_size=200).filter(lambda s: s.strip()),
+    st.just("app.py"),
+    st.just("src/module.py"),
+    st.just("/abs/path/to/file.py"),
+)
+
+content_strategy = st.text(min_size=1, max_size=2000)
+
+summary_strategy = st.text(min_size=1, max_size=500)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_cache_entry(content: str, summary: str) -> dict:
+    """Cria uma entrada de cache com hash calculado a partir do conteúdo."""
+    content_hash = hashlib.sha256(content.encode("utf-8")).hexdigest()
+    return {
+        "content_hash": content_hash,
+        "summary": summary,
+        "symbols": [],
+        "imports": [],
+        "token_estimate": 0,
+        "metadata": {},
+    }
+
+
+def _make_stale_cache_entry(summary: str) -> dict:
+    """Cria uma entrada de cache com hash diferente do conteúdo atual."""
+    return {
+        "content_hash": "0000000000000000000000000000000000000000000000000000000000000000",
+        "summary": summary,
+        "symbols": [],
+        "imports": [],
+        "token_estimate": 0,
+        "metadata": {},
+    }
+
+
+# ---------------------------------------------------------------------------
+# Testes unitários concretos
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizerUnit:
+    """Testes unitários concretos do Summarizer."""
+
+    def test_summarize_returns_str(self):
+        """O método summarize sempre retorna str."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = "Resumo do arquivo."
+        summarizer = Summarizer(llm_client=mock_llm)
+
+        result = summarizer.summarize("app.py", "def main(): pass")
+
+        assert isinstance(result, str)
+
+    def test_summarize_without_cache_calls_llm(self):
+        """Sem FileCache, o LLM é chamado a cada invocação."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = "Resumo gerado."
+        summarizer = Summarizer(llm_client=mock_llm, cache=None)
+
+        result = summarizer.summarize("app.py", "def main(): pass")
+
+        mock_llm.complete.assert_called_once()
+        assert result == "Resumo gerado."
+
+    def test_fallback_message_is_nonempty(self):
+        """FALLBACK_MESSAGE é uma string não vazia."""
+        assert isinstance(FALLBACK_MESSAGE, str)
+        assert len(FALLBACK_MESSAGE) > 0
+
+    def test_llm_client_injected_not_instantiated(self):
+        """Summarizer não instancia LLMClientProtocol diretamente."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        summarizer = Summarizer(llm_client=mock_llm)
+
+        # O atributo privado deve ser exatamente o objeto injetado
+        assert summarizer._llm_client is mock_llm
+
+    def test_empty_content_returns_empty_string(self):
+        """Conteúdo vazio retorna string vazia sem chamar o LLM."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        summarizer = Summarizer(llm_client=mock_llm)
+
+        result = summarizer.summarize("app.py", "")
+
+        assert result == ""
+        mock_llm.complete.assert_not_called()
+
+    def test_cache_hit_returns_cached_summary(self):
+        """Cache hit retorna o resumo cacheado sem chamar o LLM."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_cache = MagicMock(spec=FileCache)
+        content = "def main(): pass"
+        cached_summary = "Resumo cacheado."
+        mock_cache.get_cached_file.return_value = _make_cache_entry(
+            content, cached_summary
+        )
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        result = summarizer.summarize("app.py", content)
+
+        assert result == cached_summary
+        mock_llm.complete.assert_not_called()
+
+    def test_cache_miss_calls_llm_and_persists(self):
+        """Cache miss chama o LLM e persiste o resumo no cache."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = "Novo resumo."
+        mock_cache = MagicMock(spec=FileCache)
+        mock_cache.get_cached_file.return_value = None
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        result = summarizer.summarize("app.py", "def main(): pass")
+
+        assert result == "Novo resumo."
+        mock_llm.complete.assert_called_once()
+        mock_cache.update_cached_file.assert_called_once()
+        mock_cache.save_cache.assert_called_once()
+
+    def test_llm_failure_returns_fallback(self):
+        """Falha do LLM retorna FALLBACK_MESSAGE sem propagar exceção."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.side_effect = RuntimeError("API indisponível")
+        summarizer = Summarizer(llm_client=mock_llm)
+
+        result = summarizer.summarize("app.py", "def main(): pass")
+
+        assert result == FALLBACK_MESSAGE
+
+    def test_llm_failure_does_not_persist_cache(self):
+        """Falha do LLM não persiste nada no cache."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.side_effect = Exception("Erro genérico")
+        mock_cache = MagicMock(spec=FileCache)
+        mock_cache.get_cached_file.return_value = None
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        summarizer.summarize("app.py", "def main(): pass")
+
+        mock_cache.update_cached_file.assert_not_called()
+        mock_cache.save_cache.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Testes de logging (opcionais)
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizerLogging:
+    """Testes de logging do Summarizer."""
+
+    def test_summarize_logs_cache_hit(self, caplog):
+        """Cache hit é registrado no log."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_cache = MagicMock(spec=FileCache)
+        content = "def main(): pass"
+        mock_cache.get_cached_file.return_value = _make_cache_entry(
+            content, "Resumo cacheado."
+        )
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        with caplog.at_level(logging.INFO, logger="tokemize.summarizer"):
+            summarizer.summarize("app.py", content)
+
+        assert any("Cache hit" in record.message for record in caplog.records)
+
+    def test_summarize_logs_cache_miss(self, caplog):
+        """Cache miss é registrado no log."""
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = "Resumo."
+        mock_cache = MagicMock(spec=FileCache)
+        mock_cache.get_cached_file.return_value = None
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        with caplog.at_level(logging.DEBUG, logger="tokemize.summarizer"):
+            summarizer.summarize("app.py", "def main(): pass")
+
+        assert any("Cache miss" in record.message for record in caplog.records)
+
+    def test_api_key_not_logged(self, caplog):
+        """O valor de uma API key não aparece nos logs do Summarizer."""
+        fake_api_key = "sk-supersecretkey12345"
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = "Resumo."
+
+        summarizer = Summarizer(llm_client=mock_llm)
+        with caplog.at_level(logging.DEBUG, logger="tokemize.summarizer"):
+            summarizer.summarize("app.py", "def main(): pass")
+
+        for record in caplog.records:
+            assert fake_api_key not in record.message
+
+
+# ---------------------------------------------------------------------------
+# Property-Based Tests (Hypothesis)
+# ---------------------------------------------------------------------------
+
+
+class TestSummarizerProperties:
+    """Testes baseados em propriedades do Summarizer."""
+
+    # Feature: tokemize-summarizer, Property 1: Conteúdo vazio retorna string vazia sem chamar o LLM
+    @given(file_path=file_path_strategy)
+    @settings(max_examples=100)
+    def test_empty_content_returns_empty_no_llm_call(self, file_path: str):
+        """Property 1: Conteúdo vazio retorna string vazia sem chamar o LLM.
+
+        Validates: Requirements 1.5
+        """
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        summarizer = Summarizer(llm_client=mock_llm)
+
+        result = summarizer.summarize(file_path, "")
+
+        assert result == ""
+        mock_llm.complete.assert_not_called()
+
+    # Feature: tokemize-summarizer, Property 2: Cache hit evita chamada ao LLM
+    @given(
+        file_path=file_path_strategy,
+        content=content_strategy,
+        summary=summary_strategy,
+    )
+    @settings(max_examples=100)
+    def test_cache_hit_skips_llm(
+        self, file_path: str, content: str, summary: str
+    ):
+        """Property 2: Cache hit evita chamada ao LLM.
+
+        Validates: Requirements 2.1
+        """
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_cache = MagicMock(spec=FileCache)
+        mock_cache.get_cached_file.return_value = _make_cache_entry(
+            content, summary
+        )
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        result = summarizer.summarize(file_path, content)
+
+        assert result == summary
+        mock_llm.complete.assert_not_called()
+
+    # Feature: tokemize-summarizer, Property 3: Resumo gerado é persistido no cache
+    @given(
+        file_path=file_path_strategy,
+        content=content_strategy,
+        summary=summary_strategy,
+    )
+    @settings(max_examples=100)
+    def test_successful_summary_persisted_in_cache(
+        self, file_path: str, content: str, summary: str
+    ):
+        """Property 3: Resumo gerado é persistido no cache.
+
+        Validates: Requirements 2.2
+        """
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = summary
+        mock_cache = MagicMock(spec=FileCache)
+        mock_cache.get_cached_file.return_value = None
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        summarizer.summarize(file_path, content)
+
+        mock_cache.update_cached_file.assert_called_once()
+        call_kwargs = mock_cache.update_cached_file.call_args
+        assert call_kwargs.kwargs.get("summary") == summary or (
+            len(call_kwargs.args) > 1 and summary in call_kwargs.args
+        )
+        mock_cache.save_cache.assert_called_once()
+
+    # Feature: tokemize-summarizer, Property 4: Falha do LLM retorna fallback sem propagar exceção
+    @given(
+        file_path=file_path_strategy,
+        content=content_strategy,
+    )
+    @settings(max_examples=100)
+    def test_llm_failure_returns_fallback_no_exception(
+        self, file_path: str, content: str
+    ):
+        """Property 4: Falha do LLM retorna fallback sem propagar exceção.
+
+        Validates: Requirements 3.1, 3.2, 3.3, 3.4
+        """
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.side_effect = Exception("Falha simulada")
+        mock_cache = MagicMock(spec=FileCache)
+        mock_cache.get_cached_file.return_value = None
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+
+        # Não deve propagar exceção
+        result = summarizer.summarize(file_path, content)
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+        assert result == FALLBACK_MESSAGE
+        mock_cache.update_cached_file.assert_not_called()
+
+    # Feature: tokemize-summarizer, Property 5: Invalidação de cache por mudança de conteúdo
+    @given(
+        file_path=file_path_strategy,
+        content=content_strategy,
+        summary=summary_strategy,
+    )
+    @settings(max_examples=100)
+    def test_content_change_invalidates_cache(
+        self, file_path: str, content: str, summary: str
+    ):
+        """Property 5: Invalidação de cache por mudança de conteúdo.
+
+        O FileCache.get_cached_file já realiza a validação de hash internamente
+        e retorna None quando o hash do arquivo mudou. O Summarizer confia nesse
+        contrato: quando get_cached_file retorna None, trata como cache miss e
+        chama o LLM, gerando e persistindo um novo resumo.
+
+        Validates: Requirements 2.3
+        """
+        mock_llm = MagicMock(spec=LLMClientProtocol)
+        mock_llm.complete.return_value = summary
+        mock_cache = MagicMock(spec=FileCache)
+        # FileCache retorna None quando o hash mudou (comportamento real do FileCache)
+        mock_cache.get_cached_file.return_value = None
+
+        summarizer = Summarizer(llm_client=mock_llm, cache=mock_cache)
+        result = summarizer.summarize(file_path, content)
+
+        # LLM deve ter sido chamado (cache invalidado → miss)
+        mock_llm.complete.assert_called_once()
+        # Novo resumo deve ter sido persistido
+        mock_cache.update_cached_file.assert_called_once()
+        mock_cache.save_cache.assert_called_once()
+        assert result == summary


### PR DESCRIPTION
## Descrição

Implementa o módulo `src/tokemize/summarizer.py` responsável por gerar resumos técnicos compactos de arquivos de código-fonte usando LLM, conforme issue.

## Mudanças

- `src/tokemize/integrations/llm/protocol.py` — `LLMClientProtocol` como `typing.Protocol` para desacoplamento
- `src/tokemize/integrations/llm/openai_client.py` — `OpenAIClient` (GPT-4o) com carregamento de API key via `.env`
- `src/tokemize/integrations/llm/anthropic_client.py` — `AnthropicClient` (Claude) com carregamento de API key via `.env`
- `src/tokemize/summarizer.py` — `Summarizer` com injeção de dependência, cache via `FileCache` existente e fallback controlado
- `tests/test_summarizer.py` — 17 testes (unitários + logging + 5 property tests com Hypothesis)
- `pyproject.toml` — adiciona `hypothesis>=6.100.0` como dependência de desenvolvimento

## Critérios de aceite

- [x] Summarizer gera resumo técnico via LLM
- [x] Cache evita chamada repetida (reutiliza `FileCache` existente)
- [x] Falha na API retorna mensagem controlada sem quebrar o pipeline
- [x] API key carregada via variável de ambiente, nunca hardcoded ou logada
- [x] `LLMClientProtocol` injetado via construtor, nunca instanciado diretamente no `Summarizer`

## Testes

```
17 passed in 3.43s
```

## Checklist

- [x] A branch segue o padrão correto (`feature/summarizer-llm`)
- [x] O PR está apontando para `develop`
- [x] Testes foram executados (17/17 passando)
- [x] Não há arquivos desnecessários
