### PR TITLE
fix: corrigir JSON inválido no config.json da showcase

### DIFF
--- a/docs/showcase/config.json
+++ b/docs/showcase/config.json
@@ -147,7 +147,7 @@
       "contributions": 4,
       "html_url": "https://github.com/edunotari",
       "login": "edunotari"
-    },
+    }
   ],
   "prAuthors": [
     {
@@ -189,6 +189,6 @@
       "closed": 2,
       "avatar_url": "https://avatars.githubusercontent.com/u/65471872?v=4",
       "html_url": "https://github.com/edunotari"
-    },
+    }
   ]
 }


### PR DESCRIPTION
## O que foi feito?

Corrigida vírgula trailing após último elemento dos arrays `contributors` e `prAuthors` no `docs/showcase/config.json`. O JSON inválido causava falha no workflow `update-board-metrics` ao executar `json.load()` na linha 213.

## Tipo de mudança
- [ ] feature
- [x] fix
- [ ] docs
- [ ] refactor
- [ ] hotfix

## Checklist
- [x] A branch segue o padrão correto
- [x] O PR está apontando para a branch correta
- [ ] Testes foram executados
- [x] Não há arquivos desnecessários