### PR TITLE
fix: pin tree-sitter deps and add pytest failure log in CI

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -67,6 +67,22 @@ jobs:
             test-metrics.json
           retention-days: 7
 
+      - name: Print pytest summary if failed
+        if: env.PYTEST_EXIT_CODE != '0'
+        run: |
+          echo "=== pytest-report.json (failures only) ==="
+          python -c "
+          import json, sys
+          with open('pytest-report.json') as f:
+              report = json.load(f)
+          failed = [t for t in report.get('tests', []) if t.get('outcome') == 'failed']
+          for t in failed:
+              print('FAILED:', t['nodeid'])
+              print(t.get('call', {}).get('longrepr', '(no traceback)'))
+              print('---')
+          print(f'Total failed: {len(failed)}')
+          "
+
       - name: Fail job if pytest failed
         run: |
           echo "pytest exited with code $PYTEST_EXIT_CODE"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,10 +9,10 @@ description = "Otimização de contexto para desenvolvimento de software"
 requires-python = ">=3.11"
 dependencies = [
     "tree-sitter==0.25.2",
-    "tree-sitter-python",
-    "tree-sitter-java",
-    "tree-sitter-javascript",
-    "tree-sitter-typescript",
+    "tree-sitter-python==0.25.0",
+    "tree-sitter-java==0.23.5",
+    "tree-sitter-javascript==0.25.0",
+    "tree-sitter-typescript==0.23.2",
     "typer==0.12.3",
     "pyperclip>=1.8.2",
 ]


### PR DESCRIPTION
## Summary

Corrige falha intermitente no CI causada por dependências `tree-sitter-*` sem versão fixada, e adiciona log de falhas do pytest para facilitar diagnóstico futuro.

## Changes

- `pyproject.toml`: fixadas as versões de `tree-sitter-python==0.25.0`, `tree-sitter-java==0.23.5`, `tree-sitter-javascript==0.25.0` e `tree-sitter-typescript==0.23.2`
- `.github/workflows/ci-tests.yml`: adicionado step `Print pytest summary if failed` que imprime o traceback de cada teste falho diretamente no log do CI

## Testing

Todos os 269 testes passam localmente após as mudanças:

```
269 passed, 3 skipped in 18.65s
```
