### PR TITLE
hotfix: prevent workflow execution loop

### DIFF
--- a/.github/workflows/ci-tests.yml
+++ b/.github/workflows/ci-tests.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - main
       - develop
+    paths-ignore:
+      - docs/showcase/config.json
 
 concurrency:
   group: ci-tests-${{ github.ref }}
@@ -87,9 +89,3 @@ jobs:
         run: |
           echo "pytest exited with code $PYTEST_EXIT_CODE"
           exit "$PYTEST_EXIT_CODE"
-
-      - name: Trigger metrics updater
-        if: github.ref == 'refs/heads/main' && github.event_name == 'push'
-        run: gh workflow run update-board-metrics.yml
-        env:
-          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}

--- a/.github/workflows/update-board-metrics.yml
+++ b/.github/workflows/update-board-metrics.yml
@@ -6,9 +6,8 @@ on:
   workflow_dispatch:
   push:
     branches: [main]
-    paths:
-      # Não re-disparar quando o próprio workflow atualiza o config.json
-      - '!docs/showcase/config.json'
+    paths-ignore:
+      - docs/showcase/config.json
 
 concurrency:
   group: update-board-metrics


### PR DESCRIPTION
## Summary
- prevent CI from running on config-only metric sync pushes
- stop metrics workflow from re-triggering on its own config commit
- remove the redundant manual metrics workflow dispatch from CI

## Context
This hotfix breaks a GitHub Actions execution loop caused by the metrics workflow committing back to main and retriggering CI.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Otimizadas as automações de CI/CD para ignorar alterações em arquivos de configuração de documentação
  * Melhorado o tratamento de erros nos processos de teste e integração contínua

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IA-para-DEVs-SCTEC-T2/mini-projeto-tokemize/pull/93)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->