### PR TITLE
hotfix: load showcase test metrics from CI artifact

### DIFF
--- a/.github/workflows/update-board-metrics.yml
+++ b/.github/workflows/update-board-metrics.yml
@@ -4,10 +4,10 @@ on:
   schedule:
     - cron: '0 */6 * * *'
   workflow_dispatch:
-  push:
+  workflow_run:
+    workflows: ["CI Tests"]
+    types: [completed]
     branches: [main]
-    paths-ignore:
-      - docs/showcase/config.json
 
 concurrency:
   group: update-board-metrics
@@ -28,6 +28,19 @@ jobs:
         with:
           fetch-depth: 0
           token: ${{ secrets.PROJECT_TOKEN }}
+
+      - name: Download test artifacts from CI run
+        if: github.event_name == 'workflow_run'
+        env:
+          GH_TOKEN: ${{ secrets.PROJECT_TOKEN }}
+          RUN_ID: ${{ github.event.workflow_run.id }}
+        run: |
+          mkdir -p /tmp/test-results
+          if gh run download "$RUN_ID" --repo "$GITHUB_REPOSITORY" -n test-results -D /tmp/test-results; then
+            echo "Artifacts downloaded from CI run $RUN_ID"
+          else
+            echo "No test-results artifact found for CI run $RUN_ID"
+          fi
 
       - name: Fetch all metrics via REST + GraphQL
         id: metrics
@@ -118,8 +131,13 @@ jobs:
       - name: Read test metrics (if available)
         id: test_metrics
         run: |
-          if [ -f "/tmp/test-metrics.json" ]; then
-            echo "Test metrics found, copying to /tmp/test_metrics_data.json"
+          ARTIFACT_METRICS_FILE=$(find /tmp/test-results -name 'test-metrics.json' 2>/dev/null | head -n 1)
+
+          if [ -n "$ARTIFACT_METRICS_FILE" ] && [ -f "$ARTIFACT_METRICS_FILE" ]; then
+            echo "Test metrics artifact found at $ARTIFACT_METRICS_FILE"
+            cat "$ARTIFACT_METRICS_FILE" > /tmp/test_metrics_data.json
+          elif [ -f "/tmp/test-metrics.json" ]; then
+            echo "Local test metrics found, copying to /tmp/test_metrics_data.json"
             cat /tmp/test-metrics.json > /tmp/test_metrics_data.json
           else
             echo "No test metrics available, will use previous values"


### PR DESCRIPTION
## Summary
- trigger the metrics updater after the CI Tests workflow completes on main
- download the 	est-results artifact from the completed CI run
- load 	est-metrics.json from the artifact before falling back to previous values

## Context
This fixes the showcase test metrics flow, where the updater was reading /tmp/test-metrics.json in a different workflow run and always falling back to unknown/zero values.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Melhorado o fluxo de atualização de métricas: o workflow agora captura automaticamente métricas de testes de execuções anteriores, facilitando a propagação de dados de testes para o processo de atualização de configuração. Incluído suporte a fallback para casos onde artefatos não estão disponíveis.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/IA-para-DEVs-SCTEC-T2/mini-projeto-tokemize/pull/94)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->